### PR TITLE
Add record label filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,11 @@
         <div id="artist-list" role="group" aria-label="Filter by artist"></div>
       </div>
 
+      <div id="label-filter-section">
+        <h3>Record Label</h3>
+        <div id="label-list" role="group" aria-label="Filter by record label"></div>
+      </div>
+
       <div id="genre-filter-section">
         <h3>Genre</h3>
         <div id="genre-list" role="group" aria-label="Filter by genre"></div>


### PR DESCRIPTION
## Summary
- add record label checkbox filter in the UI
- parse and normalize song label information and remove labels from tag filters
- support filtering by record label along with existing criteria

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689130311ca8832da0f25c256bbd7349