### PR TITLE
Split multi subgenres into separate entries

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,7 +92,7 @@ function deriveMoods(song) {
   const text = (
     (song.description || '') + ' ' +
     (Array.isArray(song.tags) ? song.tags.join(' ') : '') + ' ' +
-    (song.subgenre || '')
+    (Array.isArray(song.subgenre) ? song.subgenre.join(' ') : (song.subgenre || ''))
   ).toLowerCase();
   const moods = new Set();
   for (const [mood, keywords] of Object.entries(MOOD_KEYWORDS)) {

--- a/song.html
+++ b/song.html
@@ -296,7 +296,7 @@
       const text = (
         (song.description || '') + ' ' +
         (Array.isArray(song.tags) ? song.tags.join(' ') : '') + ' ' +
-        (song.subgenre || '')
+        Array.isArray(song.subgenre) ? song.subgenre.join(' ') : (song.subgenre || '')
       ).toLowerCase();
       const moods = new Set();
       for (const [mood, keywords] of Object.entries(MOOD_KEYWORDS)) {
@@ -322,7 +322,7 @@
       const details = {
         'Country': Array.isArray(song.country) ? song.country.join(', ') : (song.country || 'Unknown'),
         'Genres': song.genre || 'N/A',
-        'Subgenres': song.subgenre || 'N/A',
+        'Subgenres': Array.isArray(song.subgenre) && song.subgenre.length ? song.subgenre.join(', ') : (song.subgenre || 'N/A'),
         'Label': song.label || 'N/A',
         'Aliases': (Array.isArray(song.aliases) && song.aliases.length) ? song.aliases.join(', ') : 'None',
         'Chart Info': song.chartInfo || 'None',

--- a/songs.json
+++ b/songs.json
@@ -3,7 +3,11 @@
     "id": "energy52-cafe-del-mar",
     "title": "Café Del Mar",
     "artist": "Energy 52",
-    "tags": ["trance", "1990s", "melodic"],
+    "tags": [
+      "trance",
+      "1990s",
+      "melodic"
+    ],
     "description": "“Café Del Mar” by Energy 52 is one of the most revered trance tracks of all time, blending Balearic ambient textures with melodic trance euphoria. Originally released in 1993, the track draws inspiration from the iconic Ibiza chillout bar of the same name. It opens with a slowly evolving pad that washes over the listener, leading into a cascading arpeggio and hypnotic melody that became an anthem in the global club scene. The track’s success lies in its emotional depth — it feels both introspective and uplifting, perfectly capturing the sunrise-at-the-beach atmosphere of early 90s Ibiza. Widely remixed and reissued, it has become a rite of passage for trance DJs and remains a staple in nostalgic and modern sets alike.",
     "releaseYear": 1993,
     "label": "Eye Q Records",
@@ -11,4009 +15,7991 @@
     "country": "Germany",
     "artistBorn": 1968,
     "artistPrimaryGenre": "Trance",
-    "aliases": ["Paul Schmitz-Moormann", "DJ Kid Paul"],
+    "aliases": [
+      "Paul Schmitz-Moormann",
+      "DJ Kid Paul"
+    ],
     "chartInfo": "Peaked at #24 on the UK Singles Chart during its 1997 re-release. Became a club classic across Europe.",
-    "synths": ["Roland TB-303", "Access Virus", "Waldorf Microwave"],
+    "synths": [
+      "Roland TB-303",
+      "Access Virus",
+      "Waldorf Microwave"
+    ],
     "drums": "Layered TR-909 kick with soft reverb, subtle high-pass filtered hi-hats, ambient rhythm loops",
-    "influences": ["Sven Väth", "Klaus Schulze", "Vangelis"],
+    "influences": [
+      "Sven Väth",
+      "Klaus Schulze",
+      "Vangelis"
+    ],
     "genre": "Trance",
     "subgenre": "Balearic Trance",
-    "youtube": ["https://www.youtube.com/watch?v=dH3GSrCmzC8"]
-
+    "youtube": [
+      "https://www.youtube.com/watch?v=dH3GSrCmzC8"
+    ]
   },
   {
-  "id": "ferry-corsten-madagascar",
-  "title": "Madagascar (Ferry Corsten Remix)",
-  "artist": "Art of Trance",
-  "tags": ["trance", "uplifting", "remix", "1990s"],
-  "description": "Ferry Corsten’s remix of Art of Trance’s 'Madagascar' is a soaring trance anthem known for its massive synth leads and euphoric breakdowns. Originally released in 1999, the remix transformed the track into a peak-time club favorite. The track’s powerful melodic structure, layered pads, and signature 303-style arpeggios contributed to its legendary status in late-90s trance. Corsten's clean production and dramatic energy shifts helped define the golden era of uplifting trance and made this remix one of the most celebrated reworks in the genre.",
-  "releaseYear": 1999,
-  "label": "Platipus Records",
-  "album": "Madagascar (Remixes)",
-  "country": "Netherlands",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["System F", "Moonman", "Gouryella", "Pulp Victim"],
-  "chartInfo": "Club classic with significant playtime in Europe; considered one of Ferry Corsten's most iconic remixes.",
-  "synths": ["Roland JP-8000", "Access Virus", "Roland TB-303"],
-  "drums": "Pounding TR-909 kick, uplifting clap layers, tight open hats, energetic build-ups",
-  "influences": ["Jean-Michel Jarre", "Vangelis", "808 State"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=smc9rTLTtUo"] 
-  
-   },
-   {
-   "id": "luis-paris-incantation-ferry-corsten-robert-smit-remix",
-  "title": "Incantation (Ferry Corsten & Robert Smit Remix)",
-  "artist": "Luis Paris",
-  "tags": ["trance", "1990s", "uplifting", "remix"],
-  "description": "This 1998 remix of 'Incantation' by Luis Paris, crafted by Ferry Corsten and Robert Smit, is a driving trance anthem infused with the soaring melodic build-ups that defined late-90s trance. Ferry Corsten’s signature crisp synth layering and emotionally charged chord progressions shine through, while Robert Smit’s rhythmic sensibilities anchor the track with solid club energy. The remix gained underground acclaim across European clubs and was a favorite in Dutch and German trance sets, though it never charted commercially.",
-  "releaseYear": 1998,
-  "label": "Purple Eye Entertainment",
-  "album": null,
-  "country": "Netherlands",
-  "artistBorn": 1972,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Luis Paris van de Velde"],
-  "chartInfo": "Did not chart commercially, but was widely played in late-night sets in the Netherlands, Germany, and the UK.",
-  "synths": ["Roland JP-8000", "Korg M1", "Waldorf Q"],
-  "drums": "Pumping 4/4 kick with syncopated offbeat hi-hats and gated snare fills typical of late-90s trance remixes",
-  "influences": ["Ferry Corsten", "Paul van Dyk", "DJ Tiësto"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=7UJwhfD5iGQ"]
-   },
-   { 
-  "id": "matt-darey-liberation-ferry-corsten-remix",
-  "title": "Liberation (Temptation) [Ferry Corsten Remix]",
-  "artist": "Matt Darey pres. Mash Up",
-  "tags": ["trance", "2000s", "vocal", "anthemic", "remix"],
-  "description": "“Liberation (Temptation)” is a euphoric vocal trance anthem remixed by Ferry Corsten in 2000, bringing his hallmark Dutch trance sound to Matt Darey's emotionally charged original. The remix elevates the angelic vocal hook — 'Fly like an angel' — with sweeping pads, uplifting arpeggios, and a sharp, driving kick. It became a club favorite and FM radio crossover, blending mainstream accessibility with trance credibility. The remix helped solidify Ferry Corsten’s role in defining the trance sound of the early 2000s.",
-  "releaseYear": 2000,
-  "label": "Incentive Records",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": 1968,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Matt Darey", "Mash Up"],
-  "chartInfo": "Reached #19 on the UK Singles Chart in 2000. Gained heavy rotation in UK club circuits and radio.",
-  "synths": ["Roland JP-8000", "Access Virus B", "Novation Supernova"],
-  "drums": "Thumping TR-909 kick, open hi-hats, layered snare hits with gated reverb, rolling mid-range percs",
-  "influences": ["BT", "Paul Oakenfold", "Ferry Corsten"],
-  "genre": "Trance",
-  "subgenre": "Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=xZtDTCbPhU0"]
-   },
-   { 
-  "id": "push-universal-nation-ferry-corsten-remix",
-  "title": "Universal Nation (Remastered Ferry Corsten Remix)",
-  "artist": "Push",
-  "tags": ["trance", "1990s", "classic", "remix", "anthemic"],
-  "description": "Originally released in 1998 and remixed later by Ferry Corsten, this version of 'Universal Nation' retains the iconic dark energy and atmospheric power of Push’s Belgian trance classic while injecting it with Ferry’s polished Dutch trance edge. The remastered remix features sharper synth textures, tighter rhythmic structure, and enhanced low-end dynamics. Revered by fans for its blend of hypnotic energy and cinematic melody, it remains one of the most respected trance tracks of all time.",
-  "releaseYear": 1999,
-  "label": "Bonzai Records / Xtravaganza",
-  "album": null,
-  "country": "Belgium",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["M.I.K.E.", "Mike Dierickx", "The Blackmaster"],
-  "chartInfo": "Original peaked at #35 in the UK in 2000; the Ferry Corsten remix became a fan-favorite in European clubs and festivals.",
-  "synths": ["Roland JP-8000", "Access Virus A", "Nord Lead 2"],
-  "drums": "Deep analog kick, dark hi-hat groove, gated reverb snares, atmospheric FX sweeps",
-  "influences": ["Jam & Spoon", "Jean-Michel Jarre", "Ferry Corsten"],
-  "genre": "Trance",
-  "subgenre": "Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=gSdj2dGzU8g"]
-   },
+    "id": "ferry-corsten-madagascar",
+    "title": "Madagascar (Ferry Corsten Remix)",
+    "artist": "Art of Trance",
+    "tags": [
+      "trance",
+      "uplifting",
+      "remix",
+      "1990s"
+    ],
+    "description": "Ferry Corsten’s remix of Art of Trance’s 'Madagascar' is a soaring trance anthem known for its massive synth leads and euphoric breakdowns. Originally released in 1999, the remix transformed the track into a peak-time club favorite. The track’s powerful melodic structure, layered pads, and signature 303-style arpeggios contributed to its legendary status in late-90s trance. Corsten's clean production and dramatic energy shifts helped define the golden era of uplifting trance and made this remix one of the most celebrated reworks in the genre.",
+    "releaseYear": 1999,
+    "label": "Platipus Records",
+    "album": "Madagascar (Remixes)",
+    "country": "Netherlands",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "System F",
+      "Moonman",
+      "Gouryella",
+      "Pulp Victim"
+    ],
+    "chartInfo": "Club classic with significant playtime in Europe; considered one of Ferry Corsten's most iconic remixes.",
+    "synths": [
+      "Roland JP-8000",
+      "Access Virus",
+      "Roland TB-303"
+    ],
+    "drums": "Pounding TR-909 kick, uplifting clap layers, tight open hats, energetic build-ups",
+    "influences": [
+      "Jean-Michel Jarre",
+      "Vangelis",
+      "808 State"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=smc9rTLTtUo"
+    ]
+  },
   {
-  "id": "evoke-arms-of-loren-ferry-corsten-remix",
-  "title": "Arms of Loren (Ferry Corsten Remix)",
-  "artist": "E'voke",
-  "tags": ["trance", "vocal", "1990s", "remix", "uplifting"],
-  "description": "Ferry Corsten’s 1999 remix of 'Arms of Loren' transforms E’voke’s haunting vocal track into an uplifting trance anthem. While the original leaned more toward breakbeat and pop-trance, Ferry’s remix overlays a euphoric melody, lush arpeggios, and a thumping 4/4 beat that defined the late 1990s trance wave. The ethereal vocal lines float above layered synths and a sweeping breakdown, making it a club favorite and emotional high point in many classic trance sets.",
-  "releaseYear": 1999,
-  "label": "Manifesto Records",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": 1970,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["E’voke", "Kerri Brown & Marlaine Gordon"],
-  "chartInfo": "Original peaked at #25 on the UK Singles Chart in 1995; Ferry Corsten's remix gained club acclaim in 1999 and was featured on numerous trance compilations.",
-  "synths": ["Access Virus A", "Korg Trinity", "Roland JP-8000"],
-  "drums": "Classic trance kick with soft compression, filtered hi-hats, sidechained pads, and vocal stabs",
-  "influences": ["BT", "Chicane", "Ferry Corsten"],
-  "genre": "Trance",
-  "subgenre": "Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=7NKzZmLJnhA"]
-   },
-   {
-  "id": "ferry-corsten-beautiful-extended-mix",
-  "title": "Beautiful (Extended Mix)",
-  "artist": "Ferry Corsten",
-  "tags": ["trance", "2000s", "uplifting", "vocal", "anthemic"],
-  "description": "Released in 2005, 'Beautiful' is one of Ferry Corsten’s most emotionally resonant productions. The extended mix brings out the track’s full melodic arc, pairing euphoric chord progressions with heartfelt lyrics and a soaring trance structure. With its lush pads, steady buildup, and massive drop, 'Beautiful' became a staple in Ferry’s live sets and a favorite on trance radio shows. The extended version gives DJs and listeners the full experience of its emotional and musical journey.",
-  "releaseYear": 2005,
-  "label": "Flashover Recordings",
-  "album": "L.E.F.",
-  "country": "Netherlands",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["System F", "Moonman", "Pulp Victim"],
-  "chartInfo": "Charted in the Dutch Dance Top 30 and featured heavily in trance compilations and live sets during 2005–2006.",
-  "synths": ["Access Virus TI", "Roland JP-8000", "Korg Triton"],
-  "drums": "Layered kick with bright hi-hats and gated claps, sidechained pad swells, and vocal stutters",
-  "influences": ["Jean-Michel Jarre", "New Order", "Armin van Buuren"],
-  "genre": "Trance",
-  "subgenre": "Progressive Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=U7Yv-Mqz2MI"]
-   },
-   {
-  "id": "ferry-corsten-remember",
-  "title": "Remember",
-  "artist": "Ferry Corsten",
-  "tags": ["trance", "progressive", "2000s", "instrumental", "emotional"],
-  "description": "Released in 2006 as part of Ferry Corsten's 'L.E.F.' album, 'Remember' is a deep and melodic instrumental trance track that trades high-energy drops for introspective ambiance and evolving synth landscapes. It builds with warm pads and soft piano-like plucks before transitioning into a nostalgic lead line that evokes a sense of longing and reflection. Though less commercially prominent than Ferry's vocal hits, 'Remember' is beloved by longtime fans for its emotional depth and timeless feel.",
-  "releaseYear": 2006,
-  "label": "Flashover Recordings",
-  "album": "L.E.F.",
-  "country": "Netherlands",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["System F", "Moonman", "Pulp Victim"],
-  "chartInfo": "Not released as a standalone single, but became a fan-favorite album track and is often cited in Ferry’s top instrumental productions.",
-  "synths": ["Access Virus TI", "Waldorf Q", "Roland SH-201"],
-  "drums": "Smooth 4/4 trance groove with ambient percussion and subtle layered snares; minimal to support emotional tone",
-  "influences": ["Chicane", "BT", "Hybrid"],
-  "genre": "Trance",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=qPMzEAvqgUg"]
-   },
-   {
-  "id": "ferry-corsten-voema",
-  "title": "Voema",
-  "artist": "Ferry Corsten",
-  "tags": ["trance", "instrumental", "2000s", "tech", "dark"],
-  "description": "‘Voema’ is a driving instrumental trance track by Ferry Corsten, released in the early 2000s under his own name. Less melodic than some of his vocal work, 'Voema' leans into tech-trance territory, featuring gritty synth stabs, tight percussion, and a pulsing bassline that makes it a powerful club tool. It builds tension through evolving filters and layered rhythms, showcasing Ferry’s ability to craft atmosphere and momentum even without vocals. A cult favorite among DJs for its utility and energy.",
-  "releaseYear": 2004,
-  "label": "Tsunami / Flashover",
-  "album": null,
-  "country": "Netherlands",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["System F", "Moonman", "Pulp Victim"],
-  "chartInfo": "Not commercially charted, but heavily featured in Ferry Corsten’s live sets and trance compilations of the mid-2000s.",
-  "synths": ["Access Virus C", "Novation Supernova", "Roland JP-8000"],
-  "drums": "Hard 909-style kick, metallic open hats, gated snare layers with delay, techy loops",
-  "influences": ["Marco V", "Sander van Doorn", "Ferry Corsten"],
-  "genre": "Trance",
-  "subgenre": "Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=FcuzivKLzAE"]
-   },
-   { 
-  "id": "ferry-corsten-stay-awake",
-  "title": "Stay Awake",
-  "artist": "Ferry Corsten",
-  "tags": ["trance", "uplifting", "2000s", "vocal", "anthemic"],
-  "description": "Released in 2006 as part of the 'L.E.F.' era, 'Stay Awake' is a high-energy vocal trance track that blends Ferry Corsten’s signature layered synths with an emotionally charged vocal topline. The track balances melody and club power, using gated pads, rising arpeggios, and a thunderous drop that made it a favorite in Ferry’s live sets. It captures the energetic optimism that defined mid-2000s trance, while showcasing Ferry’s polished production and catchy, radio-friendly edge.",
-  "releaseYear": 2006,
-  "label": "Flashover Recordings",
-  "album": "L.E.F.",
-  "country": "Netherlands",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["System F", "Moonman", "Pulp Victim"],
-  "chartInfo": "Received strong club rotation across Europe but was not released as a standalone single. Featured on multiple compilations and live sets.",
-  "synths": ["Access Virus TI", "Korg Triton", "Roland JP-8000"],
-  "drums": "Heavy kick with gated snare hits, sidechained supersaw pads, rhythmic percussive synth pulses",
-  "influences": ["BT", "New Order", "Ferry Corsten"],
-  "genre": "Trance",
-  "subgenre": "Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Q6rB3gfAvyw"]
-   },
-   {
-  "id": "armin-van-buuren-destination",
-  "title": "Destination",
-  "artist": "Armin van Buuren",
-  "tags": ["trance", "uplifting", "2010s", "anthemic", "gaia"],
-  "description": "“Destination” is an energetic trance anthem from Armin van Buuren in collaboration with Gaia. It captures the signature Gaia style — dark, driving basslines, punchy trance rhythms, and melodic synth leads layered with cinematic tension. Often featured in Armin’s 'ASOT' sets and big-stage festival sets, this track is structured for peak-time power, balancing deep hypnotic grooves with emotional buildups. A perfect example of modern uplifting trance rooted in classic trance values.",
-  "releaseYear": 2014,
-  "label": "Armada Music",
-  "album": "A State of Trance 2014",
-  "country": "Netherlands",
-  "artistBorn": 1976,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Gaia", "Rising Star", "Perpetuous Dreamer"],
-  "chartInfo": "Featured in the 'A State of Trance 2014' compilation; highly ranked in trance charts and DJ sets.",
-  "synths": ["Access Virus TI", "Sylenth1", "Roland JP-8080"],
-  "drums": "Punchy layered kick, gated snares, syncopated hi-hats, rolling basslines",
-  "influences": ["Ferry Corsten", "Tiesto (early)", "Jean-Michel Jarre"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=7TTm8FhWfJU"]
-   },
-   {
-  "id": "ferry-corsten-fulfillment",
-  "title": "Fulfillment",
-  "artist": "Ferry Corsten",
-  "tags": ["trance", "instrumental", "2000s", "system f", "anthemic"],
-  "description": "Originally released under his System F alias, 'Fulfillment' is a deeply atmospheric trance instrumental that blends sweeping pads, rising melodic phrases, and powerful drops. It's less mainstream than Corsten’s vocal hits, but it remains a fan favorite for its immersive sound design and emotional progression. The track slowly builds from an ambient intro into a layered arpeggio climax, perfectly suited for extended sets and late-night club moments.",
-  "releaseYear": 2003,
-  "label": "Tsunami",
-  "album": "Together",
-  "country": "Netherlands",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["System F", "Moonman", "Pulp Victim"],
-  "chartInfo": "Cult favorite from the System F discography, featured on multiple trance compilations and live sets.",
-  "synths": ["Access Virus B", "Waldorf Q", "Roland JP-8080"],
-  "drums": "Soft kick under lush pads, gradual snare rolls, subtle breakbeat fills",
-  "influences": ["Chicane", "BT", "Paul van Dyk"],
-  "genre": "Trance",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=J5uq7XOSnh0"]
-   },
-   {
-  "id": "hypnotist-hardcore-u-know-the-score",
-  "title": "Hardcore U Know the Score",
-  "artist": "The Hypnotist",
-  "tags": ["hardcore", "techno", "rave", "breakbeat", "1990s"],
-  "description": "A defining anthem of the UK rave scene, 'Hardcore U Know the Score' by The Hypnotist combines rapid-fire breakbeats with thunderous 4/4 kicks, euphoric stabs, and an iconic vocal hook. Released in 1992 on Rising High Records, it exemplifies early hardcore techno's raw, rebellious energy and the transition from warehouse techno to jungle and breakcore. The track became a staple at raves and is still celebrated as a classic.",
-  "releaseYear": 1992,
-  "label": "Rising High Records",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": 1970,
-  "artistPrimaryGenre": "Hardcore Techno",
-  "aliases": ["Caspar Pound", "Pete Smith"],
-  "chartInfo": "Underground rave classic, influential in shaping early UK hardcore and jungle.",
-  "synths": ["Roland Juno-106", "Roland TB-303", "Akai S1000"],
-  "drums": "Heavy 4/4 kicks, layered breakbeats, rapid snare hits",
-  "influences": ["LFO", "Orbital", "808 State"],
-  "genre": "Hardcore Techno",
-  "subgenre": "Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=yUN9eTkGHR8"] 
-   },
-   {
-  "id": "crw-i-feel-love-on-air-mix",
-  "title": "I Feel Love (On Air Mix)",
-  "artist": "CRW",
-  "tags": ["trance", "italian", "2000s", "anthemic", "club"],
-  "description": "A euphoric trance remake of Donna Summer’s disco classic, 'I Feel Love (On Air Mix)' by CRW reimagines the iconic arpeggiated synth line with a 2000s trance energy. This version blends soaring pads, a driving 4/4 beat, and filtered vocal samples to create a dancefloor anthem that was especially popular in European clubs. CRW was an alias of Mauro Picotto, a key figure in Italo trance and techno.",
-  "releaseYear": 2000,
-  "label": "Incentive Records / BXR",
-  "album": "N/A",
-  "country": "Italy",
-  "artistBorn": 1966,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Mauro Picotto", "Megavoices", "R.A.F."],
-  "chartInfo": "Reached #15 on the UK Singles Chart in 2000, a popular anthem across European club scenes.",
-  "synths": ["Roland JP-8000", "Access Virus B", "Korg MS2000"],
-  "drums": "Punchy kick drum, open hi-hats, layered snare fills, classic trance buildup patterns",
-  "influences": ["Donna Summer", "Giorgio Moroder", "Push"],
-  "genre": "Trance",
-  "subgenre": "Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=EFHnlv2sqWA"]
-   },
-   {
-  "id": "chochy-and-jonsey-salvador",
-  "title": "Salvador",
-  "artist": "Chochy & Jonsey",
-  "tags": ["hard house", "uk", "2000s", "underground", "bouncy"],
-  "description": "'Salvador' by Chochy & Jonsey is an underground hard house banger that epitomizes the energy of early 2000s UK club culture. With a pounding 4/4 kick, distorted synth riff, and bouncy rhythm, it’s a high-intensity track often heard at hard dance nights and free parties. Though not officially charting, it earned cult status among DJs in the hard house scene.",
-  "releaseYear": 2003,
-  "label": "White Label / Promo",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard House",
-  "aliases": [],
-  "chartInfo": "White label favorite in the UK hard house circuit; supported by local DJs and club scenes.",
-  "synths": ["Roland SH-101", "Novation Supernova", "Korg Electribe"],
-  "drums": "Hard punchy kicks, hi-pass filtered snares, galloping percussive loops",
-  "influences": ["BK", "Lisa Pin-Up", "Tidy Boys"],
-  "genre": "Hard Dance",
-  "subgenre": "Hard House",
-  "youtube": ["https://www.youtube.com/watch?v=GQGcBM9BxJ8"]
-   },
-   {
-  "id": "ppk-resurection-original",
-  "title": "ResuRection (Original Mix)",
-  "artist": "PPK",
-  "tags": ["trance", "russian", "2000s", "anthemic", "instrumental"],
-  "description": "‘ResuRection’ by Russian trance duo PPK is a soaring instrumental track that gained international acclaim in the early 2000s. Built around a haunting melody sampled from Eduard Artemyev’s 'Siberiade', it layers lush pads, atmospheric sweeps, and a driving trance rhythm. The track gained fame through Napster and was one of the first Russian electronic tracks to break into Western charts. Its melancholic-yet-energizing tone made it a global anthem.",
-  "releaseYear": 2001,
-  "label": "Perfecto Records / WEA",
-  "album": "Reload",
-  "country": "Russia",
-  "artistBorn": 1975,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Sergey Pimenov", "Alexander Polyakov"],
-  "chartInfo": "Reached #3 on the UK Singles Chart in 2002; one of the first post-Soviet dance tracks to chart globally.",
-  "synths": ["Access Virus B", "Roland JP-8000", "Korg Triton"],
-  "drums": "Pulsing trance kicks, open hi-hats, and crisp snare builds",
-  "influences": ["Eduard Artemyev", "Solar Stone", "Push"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=_UazOzKX8z8"]
-   },
-   {
-  "id": "dirt-devils-the-drill",
-  "title": "The Drill",
-  "artist": "Dirt Devils",
-  "tags": ["trance", "tech trance", "2000s", "instrumental", "anthemic"],
-  "description": "Released in 2001, 'The Drill' by Dirt Devils is a high-energy tech trance anthem known for its aggressive bassline, hypnotic synth loop, and precision-driven production. An alias of Darren Tate, the track was released on the legendary Incentive label and became a club staple. The intense rhythm and mechanical motif evoke the feeling of a relentless sonic machine, making it a standout in early 2000s trance sets.",
-  "releaseYear": 2001,
-  "label": "Incentive Records",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": 1972,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Darren Tate", "Jurgen Vries", "DT8 Project"],
-  "chartInfo": "Club favorite in the UK and Europe; widely supported by trance DJs on radio and in live sets.",
-  "synths": ["Access Virus C", "Roland JP-8000", "Novation Supernova II"],
-  "drums": "Driving 4/4 trance kicks, tight claps, gated snares, mechanical build-ups",
-  "influences": ["Marcel Woods", "Marco V", "Mauro Picotto"],
-  "genre": "Trance",
-  "subgenre": "Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=2K84xWqksV0"]
-   },
-   {
-  "id": "jonny-l-hurt-you-so-sm-mix",
-  "title": "Hurt You So (S&M Mix)",
-  "artist": "Jonny L",
-  "tags": ["breakbeat", "hardcore", "rave", "uk", "1990s"],
-  "description": "‘Hurt You So (S&M Mix)’ by Jonny L is a seminal 1992 UK rave anthem that helped define the transition from breakbeat hardcore to jungle. Known for its pitched-up vocals, euphoric piano stabs, and rolling breakbeats, the S&M Mix adds a rougher, more intense edge to the original. The track became an underground classic, widely sampled in later drum & bass tracks and still celebrated in old-school rave circles.",
-  "releaseYear": 1992,
-  "label": "XL Recordings",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": 1970,
-  "artistPrimaryGenre": "Breakbeat Hardcore",
-  "aliases": ["Mr. L", "True Steppers"],
-  "chartInfo": "Underground hit that received heavy play across pirate radio and raves; later influenced early jungle producers.",
-  "synths": ["Akai S950", "Roland Juno-106", "Korg M1"],
-  "drums": "Layered breakbeats (Amen-style), sampled snare rolls, bouncy sub kicks",
-  "influences": ["Rebel MC", "2 Bad Mice", "The Prodigy"],
-  "genre": "Hardcore",
-  "subgenre": "Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=6KHt1gYqBsE"]
-   },
-   {
-  "id": "vibes-and-wishdokta-fantasia",
-  "title": "Fantasia",
-  "artist": "Vibes & Wishdokta",
-  "tags": ["happy hardcore", "rave", "uk", "1990s", "breakbeat"],
-  "description": "‘Fantasia’ by Vibes & Wishdokta is a beloved happy hardcore anthem from the golden age of mid-90s UK rave. It blends fast breakbeats, uplifting melodies, and pitched-up vocal samples to create an ecstatic, hands-in-the-air atmosphere. Vibes & Wishdokta were key figures in shaping the cheerful, euphoric sound of happy hardcore, and 'Fantasia' remains one of their most iconic collaborations, often played at massive events like Dreamscape and Helter Skelter.",
-  "releaseYear": 1995,
-  "label": "Asylum / United Dance",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": 1970,
-  "artistPrimaryGenre": "Happy Hardcore",
-  "aliases": ["DJ Vibes", "Jimmy J & Cru-L-T", "Dougal & Vibes"],
-  "chartInfo": "Underground anthem in the UK rave circuit; featured on numerous tape packs and old-skool compilations.",
-  "synths": ["Roland JD-800", "Yamaha SY85", "Akai S3000"],
-  "drums": "Fast breakbeat loops layered over 4/4 kicks, clap snares, hi-hat rushes",
-  "influences": ["Slipmatt", "Dougal", "Seduction"],
-  "genre": "Hardcore",
-  "subgenre": "Happy Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=UO4-lpWLK9k"]
-   },
-   {
-  "id": "the-trip-check-one-pavillion-mix",
-  "title": "Check One (Pavillion Mix)",
-  "artist": "The Trip",
-  "tags": ["breakbeat", "hardcore", "1990s", "uk", "rave"],
-  "description": "‘Check One (Pavillion Mix)’ by The Trip is a gritty breakbeat hardcore tune from the early 90s UK rave scene. Known for its chopped-up breaks, deep sub-bass, and vocal samples calling to 'check one,' it captures the raw warehouse energy of the era. The Pavillion Mix in particular adds darker stabs and a more hypnotic breakdown, making it a favorite among DJs playing deeper or more underground sets during peak rave culture.",
-  "releaseYear": 1992,
-  "label": "D-Zone Records",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat Hardcore",
-  "aliases": ["DJ HMS", "The Hypnotist (related label artist)"],
-  "chartInfo": "Cult favorite in UK rave circles; released on the influential D-Zone label known for raw underground rave music.",
-  "synths": ["Roland Alpha Juno", "Akai S950", "Korg M1"],
-  "drums": "Chopped breakbeats, reverb-heavy claps, deep distorted kicks",
-  "influences": ["The Hypnotist", "Sonz of a Loop Da Loop Era", "Acen"],
-  "genre": "Hardcore",
-  "subgenre": "Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=VJ0ifIb1U28"]
-   },
-   {
-  "id": "leftfield-inspection-check-one",
-  "title": "Inspection (Check One)",
-  "artist": "Leftfield",
-  "tags": ["breakbeat", "progressive", "dub", "electronic", "1990s"],
-  "description": "‘Inspection (Check One)’ by Leftfield is a standout track from their 1995 album *Leftism*. Fusing breakbeat rhythms with dub basslines and spatial effects, the track showcases Leftfield’s signature hybrid style. With its deep grooves, echoed vocal snippets, and atmospheric layering, it bridges the gap between underground electronic and dub-influenced progressive dance music. It’s a hypnotic, genre-defying piece that helped cement *Leftism* as a cornerstone of 90s electronic music.",
-  "releaseYear": 1995,
-  "label": "Hard Hands / Columbia",
-  "album": "Leftism",
-  "country": "United Kingdom",
-  "artistBorn": 1960,
-  "artistPrimaryGenre": "Progressive House",
-  "aliases": ["Neil Barnes", "Paul Daley"],
-  "chartInfo": "Featured on the acclaimed *Leftism* album, which reached #3 on the UK Albums Chart and is considered one of the greatest electronic albums of all time.",
-  "synths": ["Roland Juno-106", "Akai S1100", "EMS Synthi AKS"],
-  "drums": "Syncopated breakbeat loops, dubby delays, analog drum machine fills",
-  "influences": ["Massive Attack", "The Orb", "Dub Syndicate"],
-  "genre": "Electronic",
-  "subgenre": "Breakbeat / Dub",
-  "youtube": ["https://www.youtube.com/watch?v=Ksy2SmfZkjw"]
-   },
-   {
-  "id": "stimulant-djs-hoover-time-captain-tinrib-remix",
-  "title": "Hoover Time (Captain Tinrib Remix)",
-  "artist": "Stimulant DJs",
-  "tags": ["hard house", "uk", "2000s", "hoover", "energetic"],
-  "description": "‘Hoover Time (Captain Tinrib Remix)’ is a turbocharged hard house track that pays homage to the iconic ‘hoover’ synth sound. Remixed by hard dance legend Captain Tinrib, this version amplifies the energy with thick basslines, relentless percussion, and aggressive modulation. It's a quintessential early 2000s UK hard house banger, designed for peak-time dancefloor destruction. Known for its raw, tongue-in-cheek attitude, the track has become a cult favorite among vinyl-spinning hard dance DJs.",
-  "releaseYear": 2002,
-  "label": "Tidy Trax / Tinrib Recordings",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard House",
-  "aliases": ["Paul Glazby", "Captain Tinrib"],
-  "chartInfo": "Popular within the UK hard house scene; featured in Tidy Weekender sets and Tinrib compilations.",
-  "synths": ["Roland Alpha Juno", "Access Virus B", "Novation Bass Station"],
-  "drums": "Hard 4/4 kick, gated snares, metallic percussion, reverse cymbals",
-  "influences": ["Tony De Vit", "Lisa Lashes", "BK"],
-  "genre": "Hard Dance",
-  "subgenre": "Hard House",
-  "youtube": ["https://www.youtube.com/watch?v=KJuYBqt6zVE"]
-   },
-   {
-  "id": "push-strange-world-2000-remake",
-  "title": "Strange World (2000 Remake)",
-  "artist": "Push",
-  "tags": ["trance", "uplifting", "belgian", "anthemic", "2000s"],
-  "description": "‘Strange World (2000 Remake)’ by Push is one of the most iconic trance anthems of the early 2000s. Originally released in 1999 and reworked in 2000, this version intensifies the atmosphere with deeper pads, sharper synth leads, and a more expansive breakdown. Its melancholic yet euphoric melody, backed by a thunderous kick and rolling bassline, made it a mainstay in global trance sets and a defining moment in the legacy of Belgian trance.",
-  "releaseYear": 2000,
-  "label": "Bonzai Records / Inferno",
-  "album": "From Beyond",
-  "country": "Belgium",
-  "artistBorn": 1973,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["M.I.K.E.", "Plastic Boy", "The Blackmaster"],
-  "chartInfo": "Reached #27 on the UK Singles Chart and became one of the most-played trance records in clubs worldwide during 2000–2002.",
-  "synths": ["Access Virus B", "Roland JP-8000", "Korg Trinity"],
-  "drums": "Thumping kick drum, galloping hi-hats, filtered snare rolls, wide reverb",
-  "influences": ["Ferry Corsten", "Airwave", "Tiesto"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=lYJvG2h8M2U"]
-   },
-   {
-  "id": "dj-ham-most-uplifting-new-decade-remix",
-  "title": "Most Uplifting (New Decade Remix)",
-  "artist": "DJ Ham",
-  "tags": ["happy hardcore", "uk", "1990s", "breakbeat", "uplifting"],
-  "description": "‘Most Uplifting (New Decade Remix)’ is a euphoric rework of DJ Ham’s happy hardcore classic. New Decade brings in even more energy with faster breakbeats, cleaner vocal sampling, and a sharper lead synth, making it a favorite among hardcore DJs in the mid-to-late 90s. The track’s catchy vocal hook, rapid-fire piano stabs, and emotional build-ups helped solidify its place as one of the genre’s most anthemic tunes.",
-  "releaseYear": 1996,
-  "label": "Just Another Label",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": 1974,
-  "artistPrimaryGenre": "Happy Hardcore",
-  "aliases": ["Jon Ham", "Ham & Demo"],
-  "chartInfo": "Cult favorite within the hardcore scene; heavily featured on tape packs and hardcore compilation CDs.",
-  "synths": ["Yamaha SY85", "Roland JD-800", "Akai S3000"],
-  "drums": "Fast-paced 4/4 kicks layered with chopped Amen breaks, snare rolls, and pitched-up percussion",
-  "influences": ["Slipmatt", "Brisk", "Dougal"],
-  "genre": "Hardcore",
-  "subgenre": "Happy Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=LPvGV2euNKo"]
-   },
-   {
-  "id": "the-hypnotist-the-house-is-mine",
-  "title": "The House Is Mine",
-  "artist": "The Hypnotist",
-  "tags": ["techno", "rave", "acid", "hardcore", "1990s", "uk"],
-  "description": "‘The House Is Mine’ by The Hypnotist is a legendary early 90s rave anthem that blends pounding techno kicks, acidic synth lines, and the iconic vocal declaration: 'This house is mine.' Released on Rising High Records, it became a defining track of the UK rave era, reflecting both the intensity and hypnotic energy of warehouse parties. Caspar Pound and Pete Smith crafted this track with a raw analog feel, making it a favorite among fans of acid techno and hardcore crossover.",
-  "releaseYear": 1991,
-  "label": "Rising High Records",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": 1970,
-  "artistPrimaryGenre": "Techno",
-  "aliases": ["Caspar Pound", "Pete Smith"],
-  "chartInfo": "Massive underground success; a staple in early rave DJ sets and one of Rising High’s most recognized releases.",
-  "synths": ["Roland TB-303", "Roland Juno-106", "Akai S1000"],
-  "drums": "Relentless 4/4 kick, claps on the 2 and 4, looped vocal samples, acid-infused percussion",
-  "influences": ["Joey Beltram", "LFO", "Aphex Twin"],
-  "genre": "Techno",
-  "subgenre": "Acid Techno / Rave Techno",
-  "youtube": ["https://www.youtube.com/watch?v=hwU8zOEul7k"]
-   },
-   {
-  "id": "current-value-higher",
-  "title": "Higher (feat. Current Value)",
-  "artist": "Current Value",
-  "tags": ["drum and bass", "neurofunk", "dark", "german", "2010s"],
-  "description": "‘Higher (feat. Current Value)’ is a ferocious neurofunk track that showcases Current Value’s signature precision-engineered sound design. With aggressive bass modulations, razor-sharp drums, and an ominous buildup, the track pushes the boundaries of drum & bass. Known for his dense, high-energy production style, Current Value brings surgical sound layering and cyberpunk intensity to every drop.",
-  "releaseYear": 2016,
-  "label": "Invisible Recordings / Critical Music",
-  "album": "N/A",
-  "country": "Germany",
-  "artistBorn": 1977,
-  "artistPrimaryGenre": "Drum and Bass",
-  "aliases": ["Tim Eliot"],
-  "chartInfo": "Praised within the neurofunk and experimental DnB scene; supported by Noisia, Black Sun Empire, and Critical Music artists.",
-  "synths": ["NI Massive", "Xfer Serum", "Ableton Operator"],
-  "drums": "Precision-cut breakbeats, glitchy snares, sub-heavy kicks, off-grid hats",
-  "influences": ["Noisia", "Phace", "Raiden"],
-  "genre": "Drum and Bass",
-  "subgenre": "Neurofunk",
-  "youtube": ["https://www.youtube.com/watch?v=FRVtzJ20H28"]
-   },
-   {
-  "id": "monm-devine-am-club-mix",
-  "title": "Devine (AM Club Mix)",
-  "artist": "M.O.N.M",
-  "tags": ["trance", "euphoric", "uplifting", "2000s", "club"],
-  "description": "‘Devine (AM Club Mix)’ by M.O.N.M is a euphoric trance track that captures the soaring melodies and emotional intensity typical of early 2000s club anthems. With bright synth leads, pulsating basslines, and a driving 4/4 rhythm, this mix builds toward a massive melodic payoff. Though obscure and often circulated through white-label compilations and YouTube uploads, it has become a cult favorite among trance enthusiasts for its warm, uplifting tone.",
-  "releaseYear": 2002,
-  "label": "White Label / Promo",
-  "album": "N/A",
-  "country": "Unknown",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Underground favorite with no official chart placement; widely shared in early 2000s trance forums and mixes.",
-  "synths": ["Roland JP-8000", "Access Virus B", "Korg Triton"],
-  "drums": "Rolling trance kick, layered snares, shimmering hi-hats, sweeping risers",
-  "influences": ["Above & Beyond", "Airwave", "System F"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Tf3Ti3prFfs"]
-   },
-   {
-  "id": "pascallan-inductive",
-  "title": "Inductive",
-  "artist": "Pascallan",
-  "tags": ["trance", "progressive", "melodic", "2020s", "underground"],
-  "description": "‘Inductive’ by Pascallan is a deeply atmospheric and progressive trance track known for its layered melodies, emotional pads, and hypnotic structure. Released in the 2020s, it channels the energy of classic late-90s trance while incorporating modern production clarity. The track builds patiently, with evolving arpeggios and lush textures that immerse the listener in a cinematic soundscape. It’s a favorite among fans of melodic underground trance.",
-  "releaseYear": 2022,
-  "label": "Melodic Beats Recordings",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Featured on select progressive trance playlists and DJ mixes; praised for its emotional depth and arrangement.",
-  "synths": ["u-he Diva", "Xfer Serum", "Access Virus TI"],
-  "drums": "Deep kick drum, airy hi-hats, soft snares, evolving percussive loops",
-  "influences": ["Solarstone", "16 Bit Lolitas", "Chicane"],
-  "genre": "Trance",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=K8DgTyS9Mvk"]
-   },
-   {
-  "id": "monks-the-sound-of-monks-tb-club-mix",
-  "title": "The Sound of Monks (TB Club Mix)",
-  "artist": "Monks",
-  "tags": ["trance", "tech trance", "club", "2000s", "european"],
-  "description": "‘The Sound of Monks (TB Club Mix)’ by Monks is a driving tech-trance track characterized by a dark melodic hook, hypnotic chant-like vocal samples, and pounding 4/4 rhythms. The TB Club Mix enhances the tension with a tight low-end groove, dramatic filter sweeps, and a ritualistic vibe that reflects the track’s title. A cult classic in European club sets, it’s known for creating deep, intense dancefloor moments.",
-  "releaseYear": 2002,
-  "label": "Nukleuz / BXR",
-  "album": "N/A",
-  "country": "Italy",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Giuseppe Ottaviani", "Andrea Ribeca" ],
-  "chartInfo": "Popular in hard trance/tech trance club circuits across Europe; supported by DJs on the BXR/Nukleuz rosters.",
-  "synths": ["Roland JP-8000", "Access Virus B", "Korg MS2000"],
-  "drums": "Heavy trance kick, crisp hats, tribal percussion layers, gated snares",
-  "influences": ["Mauro Picotto", "Mario Più", "Push"],
-  "genre": "Trance",
-  "subgenre": "Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=kzNNZa_ZQEM"]
-   },
-   {
-  "id": "paraphonetic-sons-of-a-new-generation-riva-daniel-den-ham-remix",
-  "title": "(The Sons of a) New Generation (Riva & Daniel Den Ham Remix)",
-  "artist": "Paraphonetic",
-  "tags": ["trance", "tech trance", "anthemic", "2000s", "european"],
-  "description": "‘(The Sons of a) New Generation’ gets a powerful rework from Riva & Daniel Den Ham in this tech-trance remix that blends sweeping synth stabs, gritty basslines, and a relentless 4/4 drive. Originally a Euro-trance track, this remix injects darker club energy while maintaining the anthemic edge of the original. The hypnotic lead melody and pounding rhythm made it a late-night favorite in European trance clubs during the early 2000s.",
-  "releaseYear": 2002,
-  "label": "Flesh Records",
-  "album": "N/A",
-  "country": "Netherlands",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A cult remix within the underground tech trance scene; circulated heavily on vinyl and in live club sets.",
-  "synths": ["Access Virus B", "Roland JP-8000", "Novation Supernova"],
-  "drums": "Pumping kick drum, offbeat hats, dark percussive fills, gated trance snares",
-  "influences": ["Marco V", "Cor Fijneman", "Riva"],
-  "genre": "Trance",
-  "subgenre": "Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=V_uhSKrwWHc"]
-   },
-   {
-  "id": "mono-culture-dark-desire-alternative-mix",
-  "title": "Dark Desire (Alternative Mix)",
-  "artist": "Mono Culture",
-  "tags": ["trance", "progressive", "vocal", "2000s", "european"],
-  "description": "‘Dark Desire (Alternative Mix)’ by Mono Culture is a sleek and hypnotic vocal trance track that blends haunting lyrics with deep, progressive grooves. The Alternative Mix strips back some of the radio polish for a more club-oriented feel — emphasizing the atmospheric pads, subtle arpeggios, and driving bassline. It became a low-key favorite in underground trance circles for its dark romantic tone and polished production.",
-  "releaseYear": 2002,
-  "label": "Nebula / Incentive Music",
-  "album": "N/A",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Received moderate club play and airwave support across European trance stations; favored by progressive DJs.",
-  "synths": ["Access Virus B", "Roland JP-8000", "Korg Triton"],
-  "drums": "Smooth layered kick, crisp hi-hats, reverb-laced snares, flowing build-ups",
-  "influences": ["Sasha", "Kyau vs. Albert", "Solarstone"],
-  "genre": "Trance",
-  "subgenre": "Progressive Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=f18O4oDDXo8"]
-   },
-   {
-  "id": "soltaire-chasing-clouds-cosmic-baby-free-gliding-remix",
-  "title": "Chasing Clouds (Cosmic Baby Free Gliding Remix)",
-  "artist": "Soltaire",
-  "tags": ["trance", "ambient", "progressive", "1990s", "german"],
-  "description": "‘Chasing Clouds (Cosmic Baby Free Gliding Remix)’ by Soltaire is a serene and expansive remix that blends ambient textures with progressive trance structure. Cosmic Baby infuses the track with his signature Berlin-school influences — lush pads, emotive piano phrases, and an open, gliding arrangement that lives up to the title. It’s a deeply atmospheric piece that moves away from dancefloor aggression and toward pure sonic elevation.",
-  "releaseYear": 1994,
-  "label": "MFS (Masterminded For Success)",
-  "album": "N/A",
-  "country": "Germany",
-  "artistBorn": 1970,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Harald Blüchel (Cosmic Baby)"],
-  "chartInfo": "Cult favorite on MFS; widely praised in progressive and ambient trance circles, though not commercially charted.",
-  "synths": ["Roland JD-800", "Korg Wavestation", "Oberheim Matrix-1000"],
-  "drums": "Minimal kick, soft ambient percussion, flowing rhythms with long decay tails",
-  "influences": ["Klaus Schulze", "Sven Väth", "Paul van Dyk (early MFS era)"],
-  "genre": "Trance",
-  "subgenre": "Ambient Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=9eToGBL3r7M"]
-   },
-   {
-  "id": "m-pasher-amtraxx",
-  "title": "Amtraxx",
-  "artist": "M-Pasher",
-  "tags": ["trance", "acid", "tech trance", "1990s", "underground"],
-  "description": "Released in 1995, ‘Amtraxx’ by M-Pasher is a raw, acid-driven trance track known for its pulsing 303-style basslines, hypnotic repetition, and stripped-down tech trance structure. A product of the peak underground rave scene in Europe, it delivers relentless club energy with analog warmth and minimal melodic content. The track became a favorite in vinyl-only sets for its ability to build tension and drive momentum deep into the night.",
-  "releaseYear": 1995,
-  "label": "4x4 Recordings",
-  "album": "N/A",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Tech Trance",
-  "aliases": [],
-  "chartInfo": "Obscure vinyl release; respected by hard trance DJs and collectors for its raw analog sound.",
-  "synths": ["Roland TB-303", "Roland Juno-106", "Access Virus A"],
-  "drums": "Punchy 4/4 kick, high-passed snares, minimal hi-hats, acid-tinged percussion loops",
-  "influences": ["Hardfloor", "Commander Tom", "Thomas P. Heckmann"],
-  "genre": "Trance",
-  "subgenre": "Acid Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=4kZ2CKqk9gI"]
-   },
-   {
-  "id": "john-doe-and-the-riddler-uprising",
-  "title": "Uprising",
-  "artist": "John Doe & The Riddler",
-  "tags": ["hard trance", "uk", "acid", "underground", "late 90s"],
-  "description": "Originally released in 1999 on UK label G‑Core, ‘Uprising’ by John Doe & The Riddler is a hard‑trance classic marked by its aggressive acid synth leads, rapid build‑ups, and club‑oriented drive. It became a staple in late‑night underground UK hard dance and trance sets.",
-  "releaseYear": 1999,
-  "label": "G‑Core",
-  "album": "N/A",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard Trance",
-  "aliases": ["Jon Doe", "Paul Maddox"],
-  "chartInfo": "Cult status within UK hard dance clubs; circulated via vinyl and DJ support.",
-  "synths": ["Roland JP‑8000", "Access Virus B", "Novation Supernova"],
-  "drums": "Thumping kick, acid processed snares, energetic hats",
-  "influences": ["BK", "Lab 4", "DJ Scott Brown"],
-  "genre": "Trance",
-  "subgenre": "Hard Trance / Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=TClBr9w_aTo"]
-   },
-   {
-  "id": "the-germ-control-box-23-scythe-squadron-303",
-  "title": "Control Box 23",
-  "artist": "The Germ",
-  "tags": ["acid techno", "acid", "techno", "2000s", "underground"],
-  "description": "“Control Box 23” by The Germ is an example of raw, acid‑driven techno released on the Scythe Squadron 303 label series. Characterized by its punishing TB‑303 lines, stark rhythm programming, and severe club energy, it reflects the stripped-down intensity of early 2000s acid techno warehouse sets.",
-  "releaseYear": 2002,
-  "label": "Scythe Squadron 303 / Scythe Squadron Exclusive",
-  "album": "High In Chicago EP (various artists)",
-  "country": "UK (label)",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Acid Techno",
-  "aliases": [],
-  "chartInfo": "Obscure underground vinyl release; circulated via DJs and collectors specializing in acid tech.",
-  "synths": ["Roland TB‑303", "TR‑909 samples", "analog modular sounds"],
-  "drums": "Minimal acid patterns, rigid 4/4 kick, tight claps, hypnotic percussion",
-  "influences": ["Hardfloor", "Chris Liberator", "Radial"],
-  "genre": "Techno",
-  "subgenre": "Acid Techno",
-  "youtube": ["https://www.youtube.com/watch?v=W5MCVYSYkU8"]
-   },
-   {
-  "id": "formic-acid-eternia",
-  "title": "Eternia",
-  "artist": "Formic Acid",
-  "tags": ["acid trance", "hard trance", "1995", "German", "cybertrance"],
-  "description": "“Eternia” by Formic Acid is an acid‑driven hard trance classic from 1995, released on labels including Cybertronic Records and ZYX Music. Featuring emotive acid melodies, hypnotic rhythms, and signature vocal samples—including a shouted “ETERNIA!!!”—it became a standout on the German trance scene and retains cult status among early rave revivalists.",
-  "releaseYear": 1995,
-  "label": "Cybertronic Records / ZYX Music",
-  "album": "Eternia EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Kai Mac Donald"],
-  "chartInfo": "Underground anthem of mid‑90s acid‑hard trance, frequently featured in mix compilations like *Trancemaster X*.",
-  "synths": ["Roland TB‑303", "Access Virus A", "Akai S3000"],
-  "drums": "Driving 4/4 kick, acid percussion, gated snares, vocal sample drops",
-  "influences": ["Kai Tracid", "Hardfloor", "MFS trance scene"],
-  "genre": "Trance",
-  "subgenre": "Acid Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=EmKw_LR6kP4"]
-   },
-   {
-  "id": "solarplex-we-are-terminate",
-  "title": "We Are Terminate",
-  "artist": "Solarplex",
-  "tags": ["acid trance", "hard trance", "1990s", "German", "underground"],
-  "description": "“We Are Terminate” by Solarplex is a hard‑trance track steeped in acidic energy and dark, pulsating rhythm. Officially released in **1996** on Flying Beam Records, it combines raw TB‑303 lines, crunchy synth drives, and atmospheric build‑ups emblematic of mid‑90s German hard trance.",
-  "releaseYear": 1996,
-  "label": "Flying Beam Records",
-  "album": "N/A",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Underground vinyl release; respected within European acid/hard trance collectors and DJs.",
-  "synths": ["Roland TB‑303", "Access Virus A"],
-  "drums": "Punchy 4/4 kicks, acid percussion fills, gated snares",
-  "influences": ["Hardfloor", "Kai Tracid", "Mauro Picotto"],
-  "genre": "Trance",
-  "subgenre": "Acid Hard Trance",
-  "youtube": []
-   },
-   {
-  "id": "skeet-bernoullis-equation",
-  "title": "Bernoulli’s Equation",
-  "artist": "Skeet",
-  "tags": ["acid trance", "1997", "underground", "tech trance"],
-  "description": "“Bernoulli’s Equation” by Skeet is a quintessential acid trance track from 1997. Released on the *Incubation EP* on acid‑focused labels, it features a hallmark rolling TB‑303 acid line, hypnotic synth layering, and driving 4/4 rhythms that typify late‑90s underground trance sounds.",
-  "releaseYear": 1997,
-  "label": "Incubation Records / DJ Skeet",
-  "album": "Incubation EP",
-  "country": "Unknown",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Skeet"],
-  "chartInfo": "Obscure vinyl EP release; circulated in underground trance collections.",
-  "synths": ["Roland TB‑303", "Access Virus", "Novation"],
-  "drums": "4/4 kick, acid snare hits, hypnotic percussive loops",
-  "influences": ["Hardfloor", "Christopher Lawrence", "Miro"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": []
-   },
-   {
-  "id": "tranceplant-active-misuse",
-  "title": "Active Misuse",
-  "artist": "Tranceplant",
-  "tags": ["acid trance", "tech-trance", "hard trance", "1990s", "underground"],
-  "description": "“Active Misuse” by Tranceplant was released in 1996 alongside “Dying Planet” on Lunacy Records (catalog LOON 9611). This acid‑laden trance track features pounding TB‑303 sequences, rigid 4/4 beats, and stripped-down layers—hallmarks of mid‑90s underground UK acid trance. It thrives on its minimalism and acid energy, making it a staple in obscure trance vinyl collections.",
-  "releaseYear": 1996,
-  "label": "Lunacy Records (Tranceplant release, LOON 9611)",
-  "album": "Dying Planet / Active Misuse 12\"",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Tech Trance",
-  "aliases": [],
-  "chartInfo": "Underground vinyl-only release; circulated via collectors and DJs in acid/trance scenes.",
-  "synths": ["Roland TB‑303", "Access Virus B"],
-  "drums": "Hard 4/4 kick, acid percussion fills, stark snare patterns",
-  "influences": ["Hardfloor", "Mauro Picotto", "Proteus (UK rave acid)"],
-  "genre": "Trance",
-  "subgenre": "Acid Tech Trance",
-  "youtube": []
-   },
-   {
-  "id": "rmb-reality-commander-tom-remix",
-  "title": "Reality (Commander Tom Remix)",
-  "artist": "RMB",
-  "tags": ["acid trance", "tech trance", "1990s", "1996", "remix", "German"],
-  "description": "This epic remix of RMB’s “Reality” was crafted by Commander Tom and released in 1996. The remix transforms the original into a high‑energy acid‑trance anthem, layering TB‑303 acid lines over punchy beats and atmospheric pads. Its sweeping breakdowns and driving rhythm captured the mid‑90s German rave sound and solidified its status as a cult classic.",
-  "releaseYear": 1996,
-  "label": "Urban / X‑Traxx",
-  "album": "Reality (Remixes)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["RMB"],
-  "chartInfo": "Underground favorite among trance/Rave DJs; featured on vinyl and CD singles of the remixes.",
-  "synths": ["Roland TB‑303", "Access Virus B", "Roland JP‑8000"],
-  "drums": "Driving kick, crisp hi‑hats, acid percussion fills, gated snares",
-  "influences": ["Commander Tom", "Frank E‑Time", "Hardfloor"],
-  "genre": "Trance",
-  "subgenre": "Acid Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=F4ajokcjwmc"]
-   },
-   {
-  "id": "dj-mishka-fifth-element",
-  "title": "Fifth Element",
-  "artist": "DJ Mishka",
-  "tags": ["acid trance", "goa trance", "1990s", "UK", "underground"],
-  "description": "“Fifth Element” by DJ Mishka is an archetypal UK acid trance track released in 1998. Known for its soaring TB‑303 acid lines, cerebral pads, and hypnotic progression, it captures the late‑90s European trance sound with gyroscopic energy and emotional build. The original and its Skyscraper Mix became cult favorites in underground trance circles.",
-  "releaseYear": 1998,
-  "label": "Voltage Controlled Frequencies (VCF)",
-  "album": "Fifth Element 12\" single",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Acid Trance",
-  "aliases": [],
-  "chartInfo": "Released as a white‑label 12\" in 1998 via VCF 011; the original and Skyscraper Mix circulated widely in UK acid trance sets.",
-  "synths": ["Roland TB‑303", "Roland Juno‑106", "Access Virus B"],
-  "drums": "Driving kick, acid percussion fills, hi‑hats, rhythmic breaks",
-  "influences": ["Hardfloor", "Goa Trance pioneers", "Voltage Controlled Frequencies labelmates"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=-7hnbZMI3e8"]
-   },
-   {
-  "id": "pablo-gargano-definition-of-a-track-david-craig-remix",
-  "title": "Definition of a Track (David Craig Remix)",
-  "artist": "Pablo Gargano",
-  "tags": ["acid trance", "tech trance", "1990s", "UK", "remix"],
-  "description": "Released in 1996, 'Definition of a Track (David Craig Remix)' takes Pablo Gargano's original and drives it deeper into acid territory with hypnotic 303 lines, heavier kick programming, and a darker, stripped-down feel. A cult favorite in the UK underground scene, it was released via Eve Records and remains a key example of mid-90s acid trance remix culture.",
-  "releaseYear": 1996,
-  "label": "Eve Records",
-  "album": "Definition of a Track 12\" single",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Popular in UK acid trance DJ sets and featured on multiple vinyl-only remix EPs during the mid-90s.",
-  "synths": ["Roland TB-303", "Access Virus A", "Juno-106"],
-  "drums": "4/4 kick, gated snares, acid break loops, echoing claps",
-  "influences": ["Tony De Vit", "Commander Tom", "Kai Tracid"],
-  "genre": "Trance",
-  "subgenre": "Acid Tech Trance",
-  "youtube": ["https://www.youtube.com/watch?v=oY56-oopeDU"]
-   },
-   {
-  "id": "bass-driver-another-world-timeless-mix",
-  "title": "Another World (Timeless Mix)",
-  "artist": "Bass Driver",
-  "tags": ["acid trance", "1990s", "1997", "underground", "Timeless Mix"],
-  "description": "Released in 1997, 'Another World (Timeless Mix)' by Bass Driver is a classic acid-trance cut built around rolling 303 basslines, driving four‑to‑the‑floor beats, and euphoric synth arpeggios. It epitomizes late-90s underground trance, popular in mix compilations and DJ sets across Europe.",
-  "releaseYear": 1997,
-  "label": "Rubble / Trancemaster X",  
-  "album": "Trancemaster X (Natural Energizer) compilation & 12\" single",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Underground favorite featured on Trancemaster compilations and acid trance collections.",
-  "synths": ["Roland TB‑303", "Access Virus B"],
-  "drums": "Steady kick, rolling acid percussion, arpeggiated snares, echoing hats",
-  "influences": ["Hardfloor", "MFS Sound", "early German trance labels"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=2q68ETzYIME"]
-   },
-   {
-  "id": "prezioso-raise-your-power",
-  "title": "Raise Your Power",
-  "artist": "Prezioso",
-  "tags": ["acid trance", "hard trance", "1990s", "1997", "Italian"],
-  "description": "Released in 1997, “Raise Your Power” by Prezioso is an energetic acid trance anthem featuring rippling TB‑303 leads, driving 4/4 kicks, and euphoric synth stabs. Issued on Trance Communications / Red Records (TRC‑R003), it became a well‑known track within European trance circuits and remains a nostalgic highlight in mid‑90s underground dance music.",
-  "releaseYear": 1997,
-  "label": "Trance Communications / Red Records",
-  "album": "Raise Your Power 12\" single",
-  "country": "Italy",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Giorgio Prezioso", "Andrea Prezioso"],
-  "chartInfo": "Vinyl-only release; highly circulated in European trance DJ sets and compilation labels.",
-  "synths": ["Roland TB‑303", "Access Virus", "Juno‑106"],
-  "drums": "Pounding kick, gated snares, acid percussion patterns, echoing hats",
-  "influences": ["Hardfloor", "Hard Trance labels", "European underground trance"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance / Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=xRH1T5kvJeQ"]
-   },
-   {
-  "id": "butsch-move",
-  "title": "Move",
-  "artist": "Butsch",
-  "tags": ["techno", "1993", "underground", "Global Ambition"],
-  "description": "“Move” (credited as Butsch – ‘Global Transfer’) is a raw, early-’90s techno track released in 1993 on the German label Global Ambition (Global Transfer EP). Known for its gritty analog textures, pounding kick, and stripped-down production, it's a classic of obscure vinyl techno pressing favored by underground DJs and early rave circuits.",
-  "releaseYear": 1993,
-  "label": "Global Ambition (Global Transfer EP)",
-  "album": "Global Transfer EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Techno",
-  "aliases": [],
-  "chartInfo": "Obscure vinyl-only release; featured on the 1993 Global Transfer EP and circulated within underground electronic circles.",
-  "synths": ["Roland SH-101", "TR-909 samples", "Analog textures"],
-  "drums": "Pounding 4/4 kick, minimal hi-hats, acid-tinged percussion loops",
-  "influences": ["German early ’90s techno", "Global Ambition label style"],
-  "genre": "Techno",
-  "subgenre": "Underground Techno",
-  "youtube": ["https://www.youtube.com/watch?v=ni0gJhv3gQk"]
-   },
-   {
-  "id": "nostrum-brainchild",
-  "title": "Brainchild",
-  "artist": "Nostrum",
-  "tags": ["hard trance", "acid trance", "1990s", "German", "classic"],
-  "description": "Released originally in the mid‑1990s, “Brainchild” by Nostrum is a landmark German hard/acid trance track celebrated for its rolling TB‑303 bass lines, euphoric melodies, and driving rhythm. It featured on vinyl singles and prominent remix EPs, becoming a go‑to in underground European trance sets.",
-  "releaseYear": 1996,
-  "label": "Time Unlimited",
-  "album": "Brainchild 12\" / The Remixes EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A cult classic within the hard trance and acid trance community; released as both the original and 1997 remix versions on vinyl and remix EPs.",
-  "synths": ["Roland TB‑303", "Access Virus A", "Novation Supernova"],
-  "drums": "Steady kick, acid percussion loops, gated snares, subtle cymbal rushes",
-  "influences": ["Hardfloor", "Time Unlimited artists", "90s German hard trance"],
-  "genre": "Trance",
-  "subgenre": "Hard Trance / Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=1kVsblFrI9o"]
-   },
-   {
-  "id": "proto-type-the-process-pro-mix",
-  "title": "The Process (Pro‑Mix)",
-  "artist": "Proto‑Type",
-  "tags": ["acid trance", "progressive trance", "1997", "German", "Pro‑Mix"],
-  "description": "Released in November 1997 on Future Recordings (FUTURE 016‑12), 'The Process (Pro‑Mix)' by Proto‑Type is a dreamy acid-trance bouncer crafted by producers Kai and Torben. Known for its floaty pads, rolling acid lines, and hypnotic groove, it became a standout of the German trance underground in the late ’90s.",
-  "releaseYear": 1997,
-  "label": "Future Recordings",
-  "album": "The Process 12\" single",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Vinyl-only release; featured in techno/trance DJ sets and Acid trance compilations.",
-  "synths": ["Roland TB‑303", "Access Virus A", "Roland Juno‑106"],
-  "drums": "Pulsing kick, acid percussion loops, lush pads, trance arpeggios",
-  "influences": ["Kai Tracid", "Cosmic Baby", "MFS label sound"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=xGAq-VsYtgo"]
-   },
-   {
-  "id": "en-garde-enfant-terrible-cruel-noise-mix",
-  "title": "Enfant Terrible (Cruel Noise Mix)",
-  "artist": "En Garde",
-  "tags": ["acid trance", "hard trance", "1990s", "German", "Cruel Noise Mix"],
-  "description": "Released in 1994, En Garde's 'Enfant Terrible' (Cruel Noise Mix) is a high‑energy acid trance track driven by sharp TB‑303 lines, pounding kicks, and aggressive synth stabs. A cult favorite appearing on compilations like *Cosmic Cubes – A Cosmic Trance Compilation Vol. I* and *Ravermeister Classics*, it embodies mid‑90s German acid‑trance style.",
-  "releaseYear": 1994,
-  "label": "Goldfinger / SPV",
-  "album": "Enfant Terrible 12\" single",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Included on major European trance compilations of the era; multiple mix versions circulated on vinyl.",
-  "synths": ["Roland TB‑303", "Access Virus B"],
-  "drums": "Driving 4/4 kick, gated snares, acid percussion, echoing hats",
-  "influences": ["Hardfloor", "DJ Hooligan", "German acid trance labels"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=PAvI3A6TKxA"]
-   },
-   {
-  "id": "aeon-fx-research-single-edit",
-  "title": "Research (Single Edit)",
-  "artist": "Aeon FX",
-  "tags": ["acid trance", "1990s", "1997", "German", "Single Edit"],
-  "description": "Released in mid‑1997 on Dos Or Die Recordings (DOS 049) and featured on the German CD maxi and vinyl single, 'Research (Single Edit)' by Aeon FX is a concise, radio‑friendly version of the acid‑trance anthem. Clocking in around 3:48, it preserves the key acid lines and atmospheric pads of the Club Mix while offering a streamlined structure for radio or compilation use.",
-  "releaseYear": 1997,
-  "label": "Dos Or Die Recordings",
-  "album": "Research 12\" single / CD maxi",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Included on German releases of CD maxi and 12″ single; secondary edits circulated on compilations and promo CDs.",
-  "synths": ["Roland TB‑303", "Access Virus A"],
-  "drums": "Tight 4/4 kick, gated percussion, acid stabs",
-  "influences": ["Hardfloor", "Kai Tracid", "Dos Or Die label style"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=v9QKjHCpl08"]
-   },
-   {
-  "id": "triple-concept-tonetwister-matic-mix",
-  "title": "Tonetwister (Matic Mix)",
-  "artist": "Triple Concept",
-  "tags": ["acid trance", "tech trance", "1999", "German", "Matic Mix"],
-  "description": "Released in 1999 on the German Tetsuo label (TET 065‑12), 'Tonetwister (Matic Mix)' by Triple Concept showcases hypnotic acid hooks and rolling rhythms typical of late‑90s underground trance. Known for its air‑raid siren sample buildup and driving groove, it became a cult classic on German vinyl and mix compilations like Acid Flash Vol. 10.",
-  "releaseYear": 1999,
-  "label": "Tetsuo (TET 065‑12)",
-  "album": "Tonetwister 12\" single",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Vinyl-only release; featured on Acid trance compilations and DJ sets across Europe.",
-  "synths": ["Roland TB‑303", "Access Virus B"],
-  "drums": "Driving 4/4 kick, acid percussion loops, filter sweeps, siren effects",
-  "influences": ["De La Ray", "Hypetraxx", "Sean Dexter"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=H69FcYQPviA"]
-   }, 
-   {
-  "id": "albion-air-palefield-mountain-remix",
-  "title": "Air (Palefield Mountain Remix)",
-  "artist": "Albion",
-  "tags": ["acid trance", "progressive trance", "1998", "UK", "remix"],
-  "description": "Released in June 1998 on Platipus (PLAT 38), Albion’s “Air (Palefield Mountain Remix)” is a sprawling acid trance epic defined by deep TB‑303 textures, rolling rhythms, and dreamy melodic evolutions. Remixed by Palefield Mountain (Adam Salkeld & Rickard Berg), it became a beloved underground trance journey across the UK and European scene.",
-  "releaseYear": 1998,
-  "label": "Platipus Music (PLAT 38)",
-  "album": "Air 12\" single",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Adam Salkeld & Rickard Berg (Palefield Mountain)"],
-  "chartInfo": "Underground cult classic; featured on multiple trance mix compilations and blog retrospectives.",
-  "synths": ["Roland TB‑303", "Access Virus B"],
-  "drums": "Deep 4/4 kick, acid percussion loops, sweeping hi‑hats, spacious cymbals",
-  "influences": ["Platipus label sound", "Jochem Paap (Speedy J)", "early UK progressive trance"],
-  "genre": "Trance",
-  "subgenre": "Acid Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=cZDL2oQhPZk"]
-   },
-   {
-  "id": "jon-the-dentist-destiny-liberator-remix",
-  "title": "Destiny (Liberator Remix)",
-  "artist": "Jon the Dentist",
-  "tags": ["acid trance", "1990s", "1996", "UK", "Liberator Remix"],
-  "description": "Released in 1996 as part of the double‑vinyl LP *Pyramid* on TEC (TEC LP24LP), ‘Destiny (Liberator Remix)’ by Jon the Dentist was remixed by Liberator DJs (Guy McAffer). The track is a classic acid-trance cut with sharp TB‑303 lines, layered pads, and driving 4/4 rhythm, widely supported in underground trance and rave circles.",
-  "releaseYear": 1996,
-  "label": "TEC (Pyramid LP, TEC LP24LP)",
-  "album": "Pyramid",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Featured on Pyramid LP and circulated in DJ sets; Liberator remix became a club favorite.",
-  "synths": ["Roland TB‑303", "Access Virus B"],
-  "drums": "Punchy kicks, acid percussion loops, gated snares",
-  "influences": ["Chris Liberator", "Guy McAffer", "UK acid trance scene"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Fk8L1JDjR_A"]
-   },
-   {
-  "id": "acidphase-dioxid",
-  "title": "Dioxid",
-  "artist": "Acidphase",
-  "tags": ["acid trance", "1996", "Germany", "Acidphase"],
-  "description": "Released in 1996 as part of the *Press* 12″ on the Acidphase label, ‘Dioxid’ is a signature acid‑trance cut featuring bubbling TB‑303 lines, metallic percussion loops, and a hypnotic rolling groove popular in European rave sets.",
-  "releaseYear": 1996,
-  "label": "Acidphase (Press 12″, 1996)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Acidphase – Dioxid"],
-  "chartInfo": "A cult track in underground acid‑trance circles, frequently included on compilations such as *Acidphase II* and *Trance Acid Experience 2* :contentReference[oaicite:1]{index=1}.",
-  "synths": ["Roland TB‑303", "SH‑101 style acid synths"],
-  "drums": "Rolled acid percussion, dry kicks, gated claps",
-  "influences": ["German acid‑trance scene", "1990s rave culture"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": []
-   },
-   {
-  "id": "ganesh-crisis-billabong-mix",
-  "title": "Crisis (Billabong Mix)",
-  "artist": "Ganesh",
-  "tags": ["acid trance", "hard trance", "1995", "UK", "Billabong Mix"],
-  "description": "Originally released in 1995 on Phoenix Rising (catalog PHX 003), ‘Crisis (Billabong Mix)’ is an acid‑trance/hard‑trance remix produced by Nigma for Billabong Productions. The mix runs at approximately 7:57, featuring deep TB‑303 acid lines, rolling percussion, and high‑energy trance power typical of mid‑90s UK rave sound.",
-  "releaseYear": 1995,
-  "label": "Phoenix Rising (PHX 003)",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "AA1 mix of the 12″ single; alongside ‘The Dentist’s Old Skool Mayhem Mix’ and 'Original M‑Zone & Chris C Mix'—a standout in underground vinyl sets :contentReference[oaicite:1]{index=1}.",
-  "synths": ["Roland TB‑303", "Analog acid synths"],
-  "drums": "Rolled acid percussion, driving kicks, tight snares",
-  "influences": ["UK acid‑hard trance", "rave sound circa 1995"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance / Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=xeZg5o1JxGI"]
+    "id": "luis-paris-incantation-ferry-corsten-robert-smit-remix",
+    "title": "Incantation (Ferry Corsten & Robert Smit Remix)",
+    "artist": "Luis Paris",
+    "tags": [
+      "trance",
+      "1990s",
+      "uplifting",
+      "remix"
+    ],
+    "description": "This 1998 remix of 'Incantation' by Luis Paris, crafted by Ferry Corsten and Robert Smit, is a driving trance anthem infused with the soaring melodic build-ups that defined late-90s trance. Ferry Corsten’s signature crisp synth layering and emotionally charged chord progressions shine through, while Robert Smit’s rhythmic sensibilities anchor the track with solid club energy. The remix gained underground acclaim across European clubs and was a favorite in Dutch and German trance sets, though it never charted commercially.",
+    "releaseYear": 1998,
+    "label": "Purple Eye Entertainment",
+    "album": null,
+    "country": "Netherlands",
+    "artistBorn": 1972,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Luis Paris van de Velde"
+    ],
+    "chartInfo": "Did not chart commercially, but was widely played in late-night sets in the Netherlands, Germany, and the UK.",
+    "synths": [
+      "Roland JP-8000",
+      "Korg M1",
+      "Waldorf Q"
+    ],
+    "drums": "Pumping 4/4 kick with syncopated offbeat hi-hats and gated snare fills typical of late-90s trance remixes",
+    "influences": [
+      "Ferry Corsten",
+      "Paul van Dyk",
+      "DJ Tiësto"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=7UJwhfD5iGQ"
+    ]
+  },
+  {
+    "id": "matt-darey-liberation-ferry-corsten-remix",
+    "title": "Liberation (Temptation) [Ferry Corsten Remix]",
+    "artist": "Matt Darey pres. Mash Up",
+    "tags": [
+      "trance",
+      "2000s",
+      "vocal",
+      "anthemic",
+      "remix"
+    ],
+    "description": "“Liberation (Temptation)” is a euphoric vocal trance anthem remixed by Ferry Corsten in 2000, bringing his hallmark Dutch trance sound to Matt Darey's emotionally charged original. The remix elevates the angelic vocal hook — 'Fly like an angel' — with sweeping pads, uplifting arpeggios, and a sharp, driving kick. It became a club favorite and FM radio crossover, blending mainstream accessibility with trance credibility. The remix helped solidify Ferry Corsten’s role in defining the trance sound of the early 2000s.",
+    "releaseYear": 2000,
+    "label": "Incentive Records",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": 1968,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Matt Darey",
+      "Mash Up"
+    ],
+    "chartInfo": "Reached #19 on the UK Singles Chart in 2000. Gained heavy rotation in UK club circuits and radio.",
+    "synths": [
+      "Roland JP-8000",
+      "Access Virus B",
+      "Novation Supernova"
+    ],
+    "drums": "Thumping TR-909 kick, open hi-hats, layered snare hits with gated reverb, rolling mid-range percs",
+    "influences": [
+      "BT",
+      "Paul Oakenfold",
+      "Ferry Corsten"
+    ],
+    "genre": "Trance",
+    "subgenre": "Vocal Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=xZtDTCbPhU0"
+    ]
+  },
+  {
+    "id": "push-universal-nation-ferry-corsten-remix",
+    "title": "Universal Nation (Remastered Ferry Corsten Remix)",
+    "artist": "Push",
+    "tags": [
+      "trance",
+      "1990s",
+      "classic",
+      "remix",
+      "anthemic"
+    ],
+    "description": "Originally released in 1998 and remixed later by Ferry Corsten, this version of 'Universal Nation' retains the iconic dark energy and atmospheric power of Push’s Belgian trance classic while injecting it with Ferry’s polished Dutch trance edge. The remastered remix features sharper synth textures, tighter rhythmic structure, and enhanced low-end dynamics. Revered by fans for its blend of hypnotic energy and cinematic melody, it remains one of the most respected trance tracks of all time.",
+    "releaseYear": 1999,
+    "label": "Bonzai Records / Xtravaganza",
+    "album": null,
+    "country": "Belgium",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "M.I.K.E.",
+      "Mike Dierickx",
+      "The Blackmaster"
+    ],
+    "chartInfo": "Original peaked at #35 in the UK in 2000; the Ferry Corsten remix became a fan-favorite in European clubs and festivals.",
+    "synths": [
+      "Roland JP-8000",
+      "Access Virus A",
+      "Nord Lead 2"
+    ],
+    "drums": "Deep analog kick, dark hi-hat groove, gated reverb snares, atmospheric FX sweeps",
+    "influences": [
+      "Jam & Spoon",
+      "Jean-Michel Jarre",
+      "Ferry Corsten"
+    ],
+    "genre": "Trance",
+    "subgenre": "Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=gSdj2dGzU8g"
+    ]
+  },
+  {
+    "id": "evoke-arms-of-loren-ferry-corsten-remix",
+    "title": "Arms of Loren (Ferry Corsten Remix)",
+    "artist": "E'voke",
+    "tags": [
+      "trance",
+      "vocal",
+      "1990s",
+      "remix",
+      "uplifting"
+    ],
+    "description": "Ferry Corsten’s 1999 remix of 'Arms of Loren' transforms E’voke’s haunting vocal track into an uplifting trance anthem. While the original leaned more toward breakbeat and pop-trance, Ferry’s remix overlays a euphoric melody, lush arpeggios, and a thumping 4/4 beat that defined the late 1990s trance wave. The ethereal vocal lines float above layered synths and a sweeping breakdown, making it a club favorite and emotional high point in many classic trance sets.",
+    "releaseYear": 1999,
+    "label": "Manifesto Records",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": 1970,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "E’voke",
+      "Kerri Brown & Marlaine Gordon"
+    ],
+    "chartInfo": "Original peaked at #25 on the UK Singles Chart in 1995; Ferry Corsten's remix gained club acclaim in 1999 and was featured on numerous trance compilations.",
+    "synths": [
+      "Access Virus A",
+      "Korg Trinity",
+      "Roland JP-8000"
+    ],
+    "drums": "Classic trance kick with soft compression, filtered hi-hats, sidechained pads, and vocal stabs",
+    "influences": [
+      "BT",
+      "Chicane",
+      "Ferry Corsten"
+    ],
+    "genre": "Trance",
+    "subgenre": "Vocal Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=7NKzZmLJnhA"
+    ]
+  },
+  {
+    "id": "ferry-corsten-beautiful-extended-mix",
+    "title": "Beautiful (Extended Mix)",
+    "artist": "Ferry Corsten",
+    "tags": [
+      "trance",
+      "2000s",
+      "uplifting",
+      "vocal",
+      "anthemic"
+    ],
+    "description": "Released in 2005, 'Beautiful' is one of Ferry Corsten’s most emotionally resonant productions. The extended mix brings out the track’s full melodic arc, pairing euphoric chord progressions with heartfelt lyrics and a soaring trance structure. With its lush pads, steady buildup, and massive drop, 'Beautiful' became a staple in Ferry’s live sets and a favorite on trance radio shows. The extended version gives DJs and listeners the full experience of its emotional and musical journey.",
+    "releaseYear": 2005,
+    "label": "Flashover Recordings",
+    "album": "L.E.F.",
+    "country": "Netherlands",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "System F",
+      "Moonman",
+      "Pulp Victim"
+    ],
+    "chartInfo": "Charted in the Dutch Dance Top 30 and featured heavily in trance compilations and live sets during 2005–2006.",
+    "synths": [
+      "Access Virus TI",
+      "Roland JP-8000",
+      "Korg Triton"
+    ],
+    "drums": "Layered kick with bright hi-hats and gated claps, sidechained pad swells, and vocal stutters",
+    "influences": [
+      "Jean-Michel Jarre",
+      "New Order",
+      "Armin van Buuren"
+    ],
+    "genre": "Trance",
+    "subgenre": "Progressive Vocal Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=U7Yv-Mqz2MI"
+    ]
+  },
+  {
+    "id": "ferry-corsten-remember",
+    "title": "Remember",
+    "artist": "Ferry Corsten",
+    "tags": [
+      "trance",
+      "progressive",
+      "2000s",
+      "instrumental",
+      "emotional"
+    ],
+    "description": "Released in 2006 as part of Ferry Corsten's 'L.E.F.' album, 'Remember' is a deep and melodic instrumental trance track that trades high-energy drops for introspective ambiance and evolving synth landscapes. It builds with warm pads and soft piano-like plucks before transitioning into a nostalgic lead line that evokes a sense of longing and reflection. Though less commercially prominent than Ferry's vocal hits, 'Remember' is beloved by longtime fans for its emotional depth and timeless feel.",
+    "releaseYear": 2006,
+    "label": "Flashover Recordings",
+    "album": "L.E.F.",
+    "country": "Netherlands",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "System F",
+      "Moonman",
+      "Pulp Victim"
+    ],
+    "chartInfo": "Not released as a standalone single, but became a fan-favorite album track and is often cited in Ferry’s top instrumental productions.",
+    "synths": [
+      "Access Virus TI",
+      "Waldorf Q",
+      "Roland SH-201"
+    ],
+    "drums": "Smooth 4/4 trance groove with ambient percussion and subtle layered snares; minimal to support emotional tone",
+    "influences": [
+      "Chicane",
+      "BT",
+      "Hybrid"
+    ],
+    "genre": "Trance",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=qPMzEAvqgUg"
+    ]
+  },
+  {
+    "id": "ferry-corsten-voema",
+    "title": "Voema",
+    "artist": "Ferry Corsten",
+    "tags": [
+      "trance",
+      "instrumental",
+      "2000s",
+      "tech",
+      "dark"
+    ],
+    "description": "‘Voema’ is a driving instrumental trance track by Ferry Corsten, released in the early 2000s under his own name. Less melodic than some of his vocal work, 'Voema' leans into tech-trance territory, featuring gritty synth stabs, tight percussion, and a pulsing bassline that makes it a powerful club tool. It builds tension through evolving filters and layered rhythms, showcasing Ferry’s ability to craft atmosphere and momentum even without vocals. A cult favorite among DJs for its utility and energy.",
+    "releaseYear": 2004,
+    "label": "Tsunami / Flashover",
+    "album": null,
+    "country": "Netherlands",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "System F",
+      "Moonman",
+      "Pulp Victim"
+    ],
+    "chartInfo": "Not commercially charted, but heavily featured in Ferry Corsten’s live sets and trance compilations of the mid-2000s.",
+    "synths": [
+      "Access Virus C",
+      "Novation Supernova",
+      "Roland JP-8000"
+    ],
+    "drums": "Hard 909-style kick, metallic open hats, gated snare layers with delay, techy loops",
+    "influences": [
+      "Marco V",
+      "Sander van Doorn",
+      "Ferry Corsten"
+    ],
+    "genre": "Trance",
+    "subgenre": "Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=FcuzivKLzAE"
+    ]
+  },
+  {
+    "id": "ferry-corsten-stay-awake",
+    "title": "Stay Awake",
+    "artist": "Ferry Corsten",
+    "tags": [
+      "trance",
+      "uplifting",
+      "2000s",
+      "vocal",
+      "anthemic"
+    ],
+    "description": "Released in 2006 as part of the 'L.E.F.' era, 'Stay Awake' is a high-energy vocal trance track that blends Ferry Corsten’s signature layered synths with an emotionally charged vocal topline. The track balances melody and club power, using gated pads, rising arpeggios, and a thunderous drop that made it a favorite in Ferry’s live sets. It captures the energetic optimism that defined mid-2000s trance, while showcasing Ferry’s polished production and catchy, radio-friendly edge.",
+    "releaseYear": 2006,
+    "label": "Flashover Recordings",
+    "album": "L.E.F.",
+    "country": "Netherlands",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "System F",
+      "Moonman",
+      "Pulp Victim"
+    ],
+    "chartInfo": "Received strong club rotation across Europe but was not released as a standalone single. Featured on multiple compilations and live sets.",
+    "synths": [
+      "Access Virus TI",
+      "Korg Triton",
+      "Roland JP-8000"
+    ],
+    "drums": "Heavy kick with gated snare hits, sidechained supersaw pads, rhythmic percussive synth pulses",
+    "influences": [
+      "BT",
+      "New Order",
+      "Ferry Corsten"
+    ],
+    "genre": "Trance",
+    "subgenre": "Vocal Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Q6rB3gfAvyw"
+    ]
+  },
+  {
+    "id": "armin-van-buuren-destination",
+    "title": "Destination",
+    "artist": "Armin van Buuren",
+    "tags": [
+      "trance",
+      "uplifting",
+      "2010s",
+      "anthemic",
+      "gaia"
+    ],
+    "description": "“Destination” is an energetic trance anthem from Armin van Buuren in collaboration with Gaia. It captures the signature Gaia style — dark, driving basslines, punchy trance rhythms, and melodic synth leads layered with cinematic tension. Often featured in Armin’s 'ASOT' sets and big-stage festival sets, this track is structured for peak-time power, balancing deep hypnotic grooves with emotional buildups. A perfect example of modern uplifting trance rooted in classic trance values.",
+    "releaseYear": 2014,
+    "label": "Armada Music",
+    "album": "A State of Trance 2014",
+    "country": "Netherlands",
+    "artistBorn": 1976,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Gaia",
+      "Rising Star",
+      "Perpetuous Dreamer"
+    ],
+    "chartInfo": "Featured in the 'A State of Trance 2014' compilation; highly ranked in trance charts and DJ sets.",
+    "synths": [
+      "Access Virus TI",
+      "Sylenth1",
+      "Roland JP-8080"
+    ],
+    "drums": "Punchy layered kick, gated snares, syncopated hi-hats, rolling basslines",
+    "influences": [
+      "Ferry Corsten",
+      "Tiesto (early)",
+      "Jean-Michel Jarre"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=7TTm8FhWfJU"
+    ]
+  },
+  {
+    "id": "ferry-corsten-fulfillment",
+    "title": "Fulfillment",
+    "artist": "Ferry Corsten",
+    "tags": [
+      "trance",
+      "instrumental",
+      "2000s",
+      "system f",
+      "anthemic"
+    ],
+    "description": "Originally released under his System F alias, 'Fulfillment' is a deeply atmospheric trance instrumental that blends sweeping pads, rising melodic phrases, and powerful drops. It's less mainstream than Corsten’s vocal hits, but it remains a fan favorite for its immersive sound design and emotional progression. The track slowly builds from an ambient intro into a layered arpeggio climax, perfectly suited for extended sets and late-night club moments.",
+    "releaseYear": 2003,
+    "label": "Tsunami",
+    "album": "Together",
+    "country": "Netherlands",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "System F",
+      "Moonman",
+      "Pulp Victim"
+    ],
+    "chartInfo": "Cult favorite from the System F discography, featured on multiple trance compilations and live sets.",
+    "synths": [
+      "Access Virus B",
+      "Waldorf Q",
+      "Roland JP-8080"
+    ],
+    "drums": "Soft kick under lush pads, gradual snare rolls, subtle breakbeat fills",
+    "influences": [
+      "Chicane",
+      "BT",
+      "Paul van Dyk"
+    ],
+    "genre": "Trance",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=J5uq7XOSnh0"
+    ]
+  },
+  {
+    "id": "hypnotist-hardcore-u-know-the-score",
+    "title": "Hardcore U Know the Score",
+    "artist": "The Hypnotist",
+    "tags": [
+      "hardcore",
+      "techno",
+      "rave",
+      "breakbeat",
+      "1990s"
+    ],
+    "description": "A defining anthem of the UK rave scene, 'Hardcore U Know the Score' by The Hypnotist combines rapid-fire breakbeats with thunderous 4/4 kicks, euphoric stabs, and an iconic vocal hook. Released in 1992 on Rising High Records, it exemplifies early hardcore techno's raw, rebellious energy and the transition from warehouse techno to jungle and breakcore. The track became a staple at raves and is still celebrated as a classic.",
+    "releaseYear": 1992,
+    "label": "Rising High Records",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": 1970,
+    "artistPrimaryGenre": "Hardcore Techno",
+    "aliases": [
+      "Caspar Pound",
+      "Pete Smith"
+    ],
+    "chartInfo": "Underground rave classic, influential in shaping early UK hardcore and jungle.",
+    "synths": [
+      "Roland Juno-106",
+      "Roland TB-303",
+      "Akai S1000"
+    ],
+    "drums": "Heavy 4/4 kicks, layered breakbeats, rapid snare hits",
+    "influences": [
+      "LFO",
+      "Orbital",
+      "808 State"
+    ],
+    "genre": "Hardcore Techno",
+    "subgenre": "Breakbeat Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=yUN9eTkGHR8"
+    ]
+  },
+  {
+    "id": "crw-i-feel-love-on-air-mix",
+    "title": "I Feel Love (On Air Mix)",
+    "artist": "CRW",
+    "tags": [
+      "trance",
+      "italian",
+      "2000s",
+      "anthemic",
+      "club"
+    ],
+    "description": "A euphoric trance remake of Donna Summer’s disco classic, 'I Feel Love (On Air Mix)' by CRW reimagines the iconic arpeggiated synth line with a 2000s trance energy. This version blends soaring pads, a driving 4/4 beat, and filtered vocal samples to create a dancefloor anthem that was especially popular in European clubs. CRW was an alias of Mauro Picotto, a key figure in Italo trance and techno.",
+    "releaseYear": 2000,
+    "label": "Incentive Records / BXR",
+    "album": "N/A",
+    "country": "Italy",
+    "artistBorn": 1966,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Mauro Picotto",
+      "Megavoices",
+      "R.A.F."
+    ],
+    "chartInfo": "Reached #15 on the UK Singles Chart in 2000, a popular anthem across European club scenes.",
+    "synths": [
+      "Roland JP-8000",
+      "Access Virus B",
+      "Korg MS2000"
+    ],
+    "drums": "Punchy kick drum, open hi-hats, layered snare fills, classic trance buildup patterns",
+    "influences": [
+      "Donna Summer",
+      "Giorgio Moroder",
+      "Push"
+    ],
+    "genre": "Trance",
+    "subgenre": "Vocal Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=EFHnlv2sqWA"
+    ]
+  },
+  {
+    "id": "chochy-and-jonsey-salvador",
+    "title": "Salvador",
+    "artist": "Chochy & Jonsey",
+    "tags": [
+      "hard house",
+      "uk",
+      "2000s",
+      "underground",
+      "bouncy"
+    ],
+    "description": "'Salvador' by Chochy & Jonsey is an underground hard house banger that epitomizes the energy of early 2000s UK club culture. With a pounding 4/4 kick, distorted synth riff, and bouncy rhythm, it’s a high-intensity track often heard at hard dance nights and free parties. Though not officially charting, it earned cult status among DJs in the hard house scene.",
+    "releaseYear": 2003,
+    "label": "White Label / Promo",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [],
+    "chartInfo": "White label favorite in the UK hard house circuit; supported by local DJs and club scenes.",
+    "synths": [
+      "Roland SH-101",
+      "Novation Supernova",
+      "Korg Electribe"
+    ],
+    "drums": "Hard punchy kicks, hi-pass filtered snares, galloping percussive loops",
+    "influences": [
+      "BK",
+      "Lisa Pin-Up",
+      "Tidy Boys"
+    ],
+    "genre": "Hard Dance",
+    "subgenre": "Hard House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=GQGcBM9BxJ8"
+    ]
+  },
+  {
+    "id": "ppk-resurection-original",
+    "title": "ResuRection (Original Mix)",
+    "artist": "PPK",
+    "tags": [
+      "trance",
+      "russian",
+      "2000s",
+      "anthemic",
+      "instrumental"
+    ],
+    "description": "‘ResuRection’ by Russian trance duo PPK is a soaring instrumental track that gained international acclaim in the early 2000s. Built around a haunting melody sampled from Eduard Artemyev’s 'Siberiade', it layers lush pads, atmospheric sweeps, and a driving trance rhythm. The track gained fame through Napster and was one of the first Russian electronic tracks to break into Western charts. Its melancholic-yet-energizing tone made it a global anthem.",
+    "releaseYear": 2001,
+    "label": "Perfecto Records / WEA",
+    "album": "Reload",
+    "country": "Russia",
+    "artistBorn": 1975,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Sergey Pimenov",
+      "Alexander Polyakov"
+    ],
+    "chartInfo": "Reached #3 on the UK Singles Chart in 2002; one of the first post-Soviet dance tracks to chart globally.",
+    "synths": [
+      "Access Virus B",
+      "Roland JP-8000",
+      "Korg Triton"
+    ],
+    "drums": "Pulsing trance kicks, open hi-hats, and crisp snare builds",
+    "influences": [
+      "Eduard Artemyev",
+      "Solar Stone",
+      "Push"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=_UazOzKX8z8"
+    ]
+  },
+  {
+    "id": "dirt-devils-the-drill",
+    "title": "The Drill",
+    "artist": "Dirt Devils",
+    "tags": [
+      "trance",
+      "tech trance",
+      "2000s",
+      "instrumental",
+      "anthemic"
+    ],
+    "description": "Released in 2001, 'The Drill' by Dirt Devils is a high-energy tech trance anthem known for its aggressive bassline, hypnotic synth loop, and precision-driven production. An alias of Darren Tate, the track was released on the legendary Incentive label and became a club staple. The intense rhythm and mechanical motif evoke the feeling of a relentless sonic machine, making it a standout in early 2000s trance sets.",
+    "releaseYear": 2001,
+    "label": "Incentive Records",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": 1972,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Darren Tate",
+      "Jurgen Vries",
+      "DT8 Project"
+    ],
+    "chartInfo": "Club favorite in the UK and Europe; widely supported by trance DJs on radio and in live sets.",
+    "synths": [
+      "Access Virus C",
+      "Roland JP-8000",
+      "Novation Supernova II"
+    ],
+    "drums": "Driving 4/4 trance kicks, tight claps, gated snares, mechanical build-ups",
+    "influences": [
+      "Marcel Woods",
+      "Marco V",
+      "Mauro Picotto"
+    ],
+    "genre": "Trance",
+    "subgenre": "Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=2K84xWqksV0"
+    ]
+  },
+  {
+    "id": "jonny-l-hurt-you-so-sm-mix",
+    "title": "Hurt You So (S&M Mix)",
+    "artist": "Jonny L",
+    "tags": [
+      "breakbeat",
+      "hardcore",
+      "rave",
+      "uk",
+      "1990s"
+    ],
+    "description": "‘Hurt You So (S&M Mix)’ by Jonny L is a seminal 1992 UK rave anthem that helped define the transition from breakbeat hardcore to jungle. Known for its pitched-up vocals, euphoric piano stabs, and rolling breakbeats, the S&M Mix adds a rougher, more intense edge to the original. The track became an underground classic, widely sampled in later drum & bass tracks and still celebrated in old-school rave circles.",
+    "releaseYear": 1992,
+    "label": "XL Recordings",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": 1970,
+    "artistPrimaryGenre": "Breakbeat Hardcore",
+    "aliases": [
+      "Mr. L",
+      "True Steppers"
+    ],
+    "chartInfo": "Underground hit that received heavy play across pirate radio and raves; later influenced early jungle producers.",
+    "synths": [
+      "Akai S950",
+      "Roland Juno-106",
+      "Korg M1"
+    ],
+    "drums": "Layered breakbeats (Amen-style), sampled snare rolls, bouncy sub kicks",
+    "influences": [
+      "Rebel MC",
+      "2 Bad Mice",
+      "The Prodigy"
+    ],
+    "genre": "Hardcore",
+    "subgenre": "Breakbeat Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=6KHt1gYqBsE"
+    ]
+  },
+  {
+    "id": "vibes-and-wishdokta-fantasia",
+    "title": "Fantasia",
+    "artist": "Vibes & Wishdokta",
+    "tags": [
+      "happy hardcore",
+      "rave",
+      "uk",
+      "1990s",
+      "breakbeat"
+    ],
+    "description": "‘Fantasia’ by Vibes & Wishdokta is a beloved happy hardcore anthem from the golden age of mid-90s UK rave. It blends fast breakbeats, uplifting melodies, and pitched-up vocal samples to create an ecstatic, hands-in-the-air atmosphere. Vibes & Wishdokta were key figures in shaping the cheerful, euphoric sound of happy hardcore, and 'Fantasia' remains one of their most iconic collaborations, often played at massive events like Dreamscape and Helter Skelter.",
+    "releaseYear": 1995,
+    "label": "Asylum / United Dance",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": 1970,
+    "artistPrimaryGenre": "Happy Hardcore",
+    "aliases": [
+      "DJ Vibes",
+      "Jimmy J & Cru-L-T",
+      "Dougal & Vibes"
+    ],
+    "chartInfo": "Underground anthem in the UK rave circuit; featured on numerous tape packs and old-skool compilations.",
+    "synths": [
+      "Roland JD-800",
+      "Yamaha SY85",
+      "Akai S3000"
+    ],
+    "drums": "Fast breakbeat loops layered over 4/4 kicks, clap snares, hi-hat rushes",
+    "influences": [
+      "Slipmatt",
+      "Dougal",
+      "Seduction"
+    ],
+    "genre": "Hardcore",
+    "subgenre": "Happy Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=UO4-lpWLK9k"
+    ]
+  },
+  {
+    "id": "the-trip-check-one-pavillion-mix",
+    "title": "Check One (Pavillion Mix)",
+    "artist": "The Trip",
+    "tags": [
+      "breakbeat",
+      "hardcore",
+      "1990s",
+      "uk",
+      "rave"
+    ],
+    "description": "‘Check One (Pavillion Mix)’ by The Trip is a gritty breakbeat hardcore tune from the early 90s UK rave scene. Known for its chopped-up breaks, deep sub-bass, and vocal samples calling to 'check one,' it captures the raw warehouse energy of the era. The Pavillion Mix in particular adds darker stabs and a more hypnotic breakdown, making it a favorite among DJs playing deeper or more underground sets during peak rave culture.",
+    "releaseYear": 1992,
+    "label": "D-Zone Records",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat Hardcore",
+    "aliases": [
+      "DJ HMS",
+      "The Hypnotist (related label artist)"
+    ],
+    "chartInfo": "Cult favorite in UK rave circles; released on the influential D-Zone label known for raw underground rave music.",
+    "synths": [
+      "Roland Alpha Juno",
+      "Akai S950",
+      "Korg M1"
+    ],
+    "drums": "Chopped breakbeats, reverb-heavy claps, deep distorted kicks",
+    "influences": [
+      "The Hypnotist",
+      "Sonz of a Loop Da Loop Era",
+      "Acen"
+    ],
+    "genre": "Hardcore",
+    "subgenre": "Breakbeat Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=VJ0ifIb1U28"
+    ]
+  },
+  {
+    "id": "leftfield-inspection-check-one",
+    "title": "Inspection (Check One)",
+    "artist": "Leftfield",
+    "tags": [
+      "breakbeat",
+      "progressive",
+      "dub",
+      "electronic",
+      "1990s"
+    ],
+    "description": "‘Inspection (Check One)’ by Leftfield is a standout track from their 1995 album *Leftism*. Fusing breakbeat rhythms with dub basslines and spatial effects, the track showcases Leftfield’s signature hybrid style. With its deep grooves, echoed vocal snippets, and atmospheric layering, it bridges the gap between underground electronic and dub-influenced progressive dance music. It’s a hypnotic, genre-defying piece that helped cement *Leftism* as a cornerstone of 90s electronic music.",
+    "releaseYear": 1995,
+    "label": "Hard Hands / Columbia",
+    "album": "Leftism",
+    "country": "United Kingdom",
+    "artistBorn": 1960,
+    "artistPrimaryGenre": "Progressive House",
+    "aliases": [
+      "Neil Barnes",
+      "Paul Daley"
+    ],
+    "chartInfo": "Featured on the acclaimed *Leftism* album, which reached #3 on the UK Albums Chart and is considered one of the greatest electronic albums of all time.",
+    "synths": [
+      "Roland Juno-106",
+      "Akai S1100",
+      "EMS Synthi AKS"
+    ],
+    "drums": "Syncopated breakbeat loops, dubby delays, analog drum machine fills",
+    "influences": [
+      "Massive Attack",
+      "The Orb",
+      "Dub Syndicate"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Breakbeat",
+      "Dub"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=Ksy2SmfZkjw"
+    ]
+  },
+  {
+    "id": "stimulant-djs-hoover-time-captain-tinrib-remix",
+    "title": "Hoover Time (Captain Tinrib Remix)",
+    "artist": "Stimulant DJs",
+    "tags": [
+      "hard house",
+      "uk",
+      "2000s",
+      "hoover",
+      "energetic"
+    ],
+    "description": "‘Hoover Time (Captain Tinrib Remix)’ is a turbocharged hard house track that pays homage to the iconic ‘hoover’ synth sound. Remixed by hard dance legend Captain Tinrib, this version amplifies the energy with thick basslines, relentless percussion, and aggressive modulation. It's a quintessential early 2000s UK hard house banger, designed for peak-time dancefloor destruction. Known for its raw, tongue-in-cheek attitude, the track has become a cult favorite among vinyl-spinning hard dance DJs.",
+    "releaseYear": 2002,
+    "label": "Tidy Trax / Tinrib Recordings",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [
+      "Paul Glazby",
+      "Captain Tinrib"
+    ],
+    "chartInfo": "Popular within the UK hard house scene; featured in Tidy Weekender sets and Tinrib compilations.",
+    "synths": [
+      "Roland Alpha Juno",
+      "Access Virus B",
+      "Novation Bass Station"
+    ],
+    "drums": "Hard 4/4 kick, gated snares, metallic percussion, reverse cymbals",
+    "influences": [
+      "Tony De Vit",
+      "Lisa Lashes",
+      "BK"
+    ],
+    "genre": "Hard Dance",
+    "subgenre": "Hard House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=KJuYBqt6zVE"
+    ]
+  },
+  {
+    "id": "push-strange-world-2000-remake",
+    "title": "Strange World (2000 Remake)",
+    "artist": "Push",
+    "tags": [
+      "trance",
+      "uplifting",
+      "belgian",
+      "anthemic",
+      "2000s"
+    ],
+    "description": "‘Strange World (2000 Remake)’ by Push is one of the most iconic trance anthems of the early 2000s. Originally released in 1999 and reworked in 2000, this version intensifies the atmosphere with deeper pads, sharper synth leads, and a more expansive breakdown. Its melancholic yet euphoric melody, backed by a thunderous kick and rolling bassline, made it a mainstay in global trance sets and a defining moment in the legacy of Belgian trance.",
+    "releaseYear": 2000,
+    "label": "Bonzai Records / Inferno",
+    "album": "From Beyond",
+    "country": "Belgium",
+    "artistBorn": 1973,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "M.I.K.E.",
+      "Plastic Boy",
+      "The Blackmaster"
+    ],
+    "chartInfo": "Reached #27 on the UK Singles Chart and became one of the most-played trance records in clubs worldwide during 2000–2002.",
+    "synths": [
+      "Access Virus B",
+      "Roland JP-8000",
+      "Korg Trinity"
+    ],
+    "drums": "Thumping kick drum, galloping hi-hats, filtered snare rolls, wide reverb",
+    "influences": [
+      "Ferry Corsten",
+      "Airwave",
+      "Tiesto"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=lYJvG2h8M2U"
+    ]
+  },
+  {
+    "id": "dj-ham-most-uplifting-new-decade-remix",
+    "title": "Most Uplifting (New Decade Remix)",
+    "artist": "DJ Ham",
+    "tags": [
+      "happy hardcore",
+      "uk",
+      "1990s",
+      "breakbeat",
+      "uplifting"
+    ],
+    "description": "‘Most Uplifting (New Decade Remix)’ is a euphoric rework of DJ Ham’s happy hardcore classic. New Decade brings in even more energy with faster breakbeats, cleaner vocal sampling, and a sharper lead synth, making it a favorite among hardcore DJs in the mid-to-late 90s. The track’s catchy vocal hook, rapid-fire piano stabs, and emotional build-ups helped solidify its place as one of the genre’s most anthemic tunes.",
+    "releaseYear": 1996,
+    "label": "Just Another Label",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": 1974,
+    "artistPrimaryGenre": "Happy Hardcore",
+    "aliases": [
+      "Jon Ham",
+      "Ham & Demo"
+    ],
+    "chartInfo": "Cult favorite within the hardcore scene; heavily featured on tape packs and hardcore compilation CDs.",
+    "synths": [
+      "Yamaha SY85",
+      "Roland JD-800",
+      "Akai S3000"
+    ],
+    "drums": "Fast-paced 4/4 kicks layered with chopped Amen breaks, snare rolls, and pitched-up percussion",
+    "influences": [
+      "Slipmatt",
+      "Brisk",
+      "Dougal"
+    ],
+    "genre": "Hardcore",
+    "subgenre": "Happy Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=LPvGV2euNKo"
+    ]
+  },
+  {
+    "id": "the-hypnotist-the-house-is-mine",
+    "title": "The House Is Mine",
+    "artist": "The Hypnotist",
+    "tags": [
+      "techno",
+      "rave",
+      "acid",
+      "hardcore",
+      "1990s",
+      "uk"
+    ],
+    "description": "‘The House Is Mine’ by The Hypnotist is a legendary early 90s rave anthem that blends pounding techno kicks, acidic synth lines, and the iconic vocal declaration: 'This house is mine.' Released on Rising High Records, it became a defining track of the UK rave era, reflecting both the intensity and hypnotic energy of warehouse parties. Caspar Pound and Pete Smith crafted this track with a raw analog feel, making it a favorite among fans of acid techno and hardcore crossover.",
+    "releaseYear": 1991,
+    "label": "Rising High Records",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": 1970,
+    "artistPrimaryGenre": "Techno",
+    "aliases": [
+      "Caspar Pound",
+      "Pete Smith"
+    ],
+    "chartInfo": "Massive underground success; a staple in early rave DJ sets and one of Rising High’s most recognized releases.",
+    "synths": [
+      "Roland TB-303",
+      "Roland Juno-106",
+      "Akai S1000"
+    ],
+    "drums": "Relentless 4/4 kick, claps on the 2 and 4, looped vocal samples, acid-infused percussion",
+    "influences": [
+      "Joey Beltram",
+      "LFO",
+      "Aphex Twin"
+    ],
+    "genre": "Techno",
+    "subgenre": [
+      "Acid Techno",
+      "Rave Techno"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=hwU8zOEul7k"
+    ]
+  },
+  {
+    "id": "current-value-higher",
+    "title": "Higher (feat. Current Value)",
+    "artist": "Current Value",
+    "tags": [
+      "drum and bass",
+      "neurofunk",
+      "dark",
+      "german",
+      "2010s"
+    ],
+    "description": "‘Higher (feat. Current Value)’ is a ferocious neurofunk track that showcases Current Value’s signature precision-engineered sound design. With aggressive bass modulations, razor-sharp drums, and an ominous buildup, the track pushes the boundaries of drum & bass. Known for his dense, high-energy production style, Current Value brings surgical sound layering and cyberpunk intensity to every drop.",
+    "releaseYear": 2016,
+    "label": "Invisible Recordings / Critical Music",
+    "album": "N/A",
+    "country": "Germany",
+    "artistBorn": 1977,
+    "artistPrimaryGenre": "Drum and Bass",
+    "aliases": [
+      "Tim Eliot"
+    ],
+    "chartInfo": "Praised within the neurofunk and experimental DnB scene; supported by Noisia, Black Sun Empire, and Critical Music artists.",
+    "synths": [
+      "NI Massive",
+      "Xfer Serum",
+      "Ableton Operator"
+    ],
+    "drums": "Precision-cut breakbeats, glitchy snares, sub-heavy kicks, off-grid hats",
+    "influences": [
+      "Noisia",
+      "Phace",
+      "Raiden"
+    ],
+    "genre": "Drum and Bass",
+    "subgenre": "Neurofunk",
+    "youtube": [
+      "https://www.youtube.com/watch?v=FRVtzJ20H28"
+    ]
+  },
+  {
+    "id": "monm-devine-am-club-mix",
+    "title": "Devine (AM Club Mix)",
+    "artist": "M.O.N.M",
+    "tags": [
+      "trance",
+      "euphoric",
+      "uplifting",
+      "2000s",
+      "club"
+    ],
+    "description": "‘Devine (AM Club Mix)’ by M.O.N.M is a euphoric trance track that captures the soaring melodies and emotional intensity typical of early 2000s club anthems. With bright synth leads, pulsating basslines, and a driving 4/4 rhythm, this mix builds toward a massive melodic payoff. Though obscure and often circulated through white-label compilations and YouTube uploads, it has become a cult favorite among trance enthusiasts for its warm, uplifting tone.",
+    "releaseYear": 2002,
+    "label": "White Label / Promo",
+    "album": "N/A",
+    "country": "Unknown",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Underground favorite with no official chart placement; widely shared in early 2000s trance forums and mixes.",
+    "synths": [
+      "Roland JP-8000",
+      "Access Virus B",
+      "Korg Triton"
+    ],
+    "drums": "Rolling trance kick, layered snares, shimmering hi-hats, sweeping risers",
+    "influences": [
+      "Above & Beyond",
+      "Airwave",
+      "System F"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Tf3Ti3prFfs"
+    ]
+  },
+  {
+    "id": "pascallan-inductive",
+    "title": "Inductive",
+    "artist": "Pascallan",
+    "tags": [
+      "trance",
+      "progressive",
+      "melodic",
+      "2020s",
+      "underground"
+    ],
+    "description": "‘Inductive’ by Pascallan is a deeply atmospheric and progressive trance track known for its layered melodies, emotional pads, and hypnotic structure. Released in the 2020s, it channels the energy of classic late-90s trance while incorporating modern production clarity. The track builds patiently, with evolving arpeggios and lush textures that immerse the listener in a cinematic soundscape. It’s a favorite among fans of melodic underground trance.",
+    "releaseYear": 2022,
+    "label": "Melodic Beats Recordings",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Featured on select progressive trance playlists and DJ mixes; praised for its emotional depth and arrangement.",
+    "synths": [
+      "u-he Diva",
+      "Xfer Serum",
+      "Access Virus TI"
+    ],
+    "drums": "Deep kick drum, airy hi-hats, soft snares, evolving percussive loops",
+    "influences": [
+      "Solarstone",
+      "16 Bit Lolitas",
+      "Chicane"
+    ],
+    "genre": "Trance",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=K8DgTyS9Mvk"
+    ]
+  },
+  {
+    "id": "monks-the-sound-of-monks-tb-club-mix",
+    "title": "The Sound of Monks (TB Club Mix)",
+    "artist": "Monks",
+    "tags": [
+      "trance",
+      "tech trance",
+      "club",
+      "2000s",
+      "european"
+    ],
+    "description": "‘The Sound of Monks (TB Club Mix)’ by Monks is a driving tech-trance track characterized by a dark melodic hook, hypnotic chant-like vocal samples, and pounding 4/4 rhythms. The TB Club Mix enhances the tension with a tight low-end groove, dramatic filter sweeps, and a ritualistic vibe that reflects the track’s title. A cult classic in European club sets, it’s known for creating deep, intense dancefloor moments.",
+    "releaseYear": 2002,
+    "label": "Nukleuz / BXR",
+    "album": "N/A",
+    "country": "Italy",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Giuseppe Ottaviani",
+      "Andrea Ribeca"
+    ],
+    "chartInfo": "Popular in hard trance/tech trance club circuits across Europe; supported by DJs on the BXR/Nukleuz rosters.",
+    "synths": [
+      "Roland JP-8000",
+      "Access Virus B",
+      "Korg MS2000"
+    ],
+    "drums": "Heavy trance kick, crisp hats, tribal percussion layers, gated snares",
+    "influences": [
+      "Mauro Picotto",
+      "Mario Più",
+      "Push"
+    ],
+    "genre": "Trance",
+    "subgenre": "Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=kzNNZa_ZQEM"
+    ]
+  },
+  {
+    "id": "paraphonetic-sons-of-a-new-generation-riva-daniel-den-ham-remix",
+    "title": "(The Sons of a) New Generation (Riva & Daniel Den Ham Remix)",
+    "artist": "Paraphonetic",
+    "tags": [
+      "trance",
+      "tech trance",
+      "anthemic",
+      "2000s",
+      "european"
+    ],
+    "description": "‘(The Sons of a) New Generation’ gets a powerful rework from Riva & Daniel Den Ham in this tech-trance remix that blends sweeping synth stabs, gritty basslines, and a relentless 4/4 drive. Originally a Euro-trance track, this remix injects darker club energy while maintaining the anthemic edge of the original. The hypnotic lead melody and pounding rhythm made it a late-night favorite in European trance clubs during the early 2000s.",
+    "releaseYear": 2002,
+    "label": "Flesh Records",
+    "album": "N/A",
+    "country": "Netherlands",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A cult remix within the underground tech trance scene; circulated heavily on vinyl and in live club sets.",
+    "synths": [
+      "Access Virus B",
+      "Roland JP-8000",
+      "Novation Supernova"
+    ],
+    "drums": "Pumping kick drum, offbeat hats, dark percussive fills, gated trance snares",
+    "influences": [
+      "Marco V",
+      "Cor Fijneman",
+      "Riva"
+    ],
+    "genre": "Trance",
+    "subgenre": "Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=V_uhSKrwWHc"
+    ]
+  },
+  {
+    "id": "mono-culture-dark-desire-alternative-mix",
+    "title": "Dark Desire (Alternative Mix)",
+    "artist": "Mono Culture",
+    "tags": [
+      "trance",
+      "progressive",
+      "vocal",
+      "2000s",
+      "european"
+    ],
+    "description": "‘Dark Desire (Alternative Mix)’ by Mono Culture is a sleek and hypnotic vocal trance track that blends haunting lyrics with deep, progressive grooves. The Alternative Mix strips back some of the radio polish for a more club-oriented feel — emphasizing the atmospheric pads, subtle arpeggios, and driving bassline. It became a low-key favorite in underground trance circles for its dark romantic tone and polished production.",
+    "releaseYear": 2002,
+    "label": "Nebula / Incentive Music",
+    "album": "N/A",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Received moderate club play and airwave support across European trance stations; favored by progressive DJs.",
+    "synths": [
+      "Access Virus B",
+      "Roland JP-8000",
+      "Korg Triton"
+    ],
+    "drums": "Smooth layered kick, crisp hi-hats, reverb-laced snares, flowing build-ups",
+    "influences": [
+      "Sasha",
+      "Kyau vs. Albert",
+      "Solarstone"
+    ],
+    "genre": "Trance",
+    "subgenre": "Progressive Vocal Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=f18O4oDDXo8"
+    ]
+  },
+  {
+    "id": "soltaire-chasing-clouds-cosmic-baby-free-gliding-remix",
+    "title": "Chasing Clouds (Cosmic Baby Free Gliding Remix)",
+    "artist": "Soltaire",
+    "tags": [
+      "trance",
+      "ambient",
+      "progressive",
+      "1990s",
+      "german"
+    ],
+    "description": "‘Chasing Clouds (Cosmic Baby Free Gliding Remix)’ by Soltaire is a serene and expansive remix that blends ambient textures with progressive trance structure. Cosmic Baby infuses the track with his signature Berlin-school influences — lush pads, emotive piano phrases, and an open, gliding arrangement that lives up to the title. It’s a deeply atmospheric piece that moves away from dancefloor aggression and toward pure sonic elevation.",
+    "releaseYear": 1994,
+    "label": "MFS (Masterminded For Success)",
+    "album": "N/A",
+    "country": "Germany",
+    "artistBorn": 1970,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Harald Blüchel (Cosmic Baby)"
+    ],
+    "chartInfo": "Cult favorite on MFS; widely praised in progressive and ambient trance circles, though not commercially charted.",
+    "synths": [
+      "Roland JD-800",
+      "Korg Wavestation",
+      "Oberheim Matrix-1000"
+    ],
+    "drums": "Minimal kick, soft ambient percussion, flowing rhythms with long decay tails",
+    "influences": [
+      "Klaus Schulze",
+      "Sven Väth",
+      "Paul van Dyk (early MFS era)"
+    ],
+    "genre": "Trance",
+    "subgenre": "Ambient Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=9eToGBL3r7M"
+    ]
+  },
+  {
+    "id": "m-pasher-amtraxx",
+    "title": "Amtraxx",
+    "artist": "M-Pasher",
+    "tags": [
+      "trance",
+      "acid",
+      "tech trance",
+      "1990s",
+      "underground"
+    ],
+    "description": "Released in 1995, ‘Amtraxx’ by M-Pasher is a raw, acid-driven trance track known for its pulsing 303-style basslines, hypnotic repetition, and stripped-down tech trance structure. A product of the peak underground rave scene in Europe, it delivers relentless club energy with analog warmth and minimal melodic content. The track became a favorite in vinyl-only sets for its ability to build tension and drive momentum deep into the night.",
+    "releaseYear": 1995,
+    "label": "4x4 Recordings",
+    "album": "N/A",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Tech Trance",
+    "aliases": [],
+    "chartInfo": "Obscure vinyl release; respected by hard trance DJs and collectors for its raw analog sound.",
+    "synths": [
+      "Roland TB-303",
+      "Roland Juno-106",
+      "Access Virus A"
+    ],
+    "drums": "Punchy 4/4 kick, high-passed snares, minimal hi-hats, acid-tinged percussion loops",
+    "influences": [
+      "Hardfloor",
+      "Commander Tom",
+      "Thomas P. Heckmann"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=4kZ2CKqk9gI"
+    ]
+  },
+  {
+    "id": "john-doe-and-the-riddler-uprising",
+    "title": "Uprising",
+    "artist": "John Doe & The Riddler",
+    "tags": [
+      "hard trance",
+      "uk",
+      "acid",
+      "underground",
+      "late 90s"
+    ],
+    "description": "Originally released in 1999 on UK label G‑Core, ‘Uprising’ by John Doe & The Riddler is a hard‑trance classic marked by its aggressive acid synth leads, rapid build‑ups, and club‑oriented drive. It became a staple in late‑night underground UK hard dance and trance sets.",
+    "releaseYear": 1999,
+    "label": "G‑Core",
+    "album": "N/A",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard Trance",
+    "aliases": [
+      "Jon Doe",
+      "Paul Maddox"
+    ],
+    "chartInfo": "Cult status within UK hard dance clubs; circulated via vinyl and DJ support.",
+    "synths": [
+      "Roland JP‑8000",
+      "Access Virus B",
+      "Novation Supernova"
+    ],
+    "drums": "Thumping kick, acid processed snares, energetic hats",
+    "influences": [
+      "BK",
+      "Lab 4",
+      "DJ Scott Brown"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Hard Trance",
+      "Acid Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=TClBr9w_aTo"
+    ]
+  },
+  {
+    "id": "the-germ-control-box-23-scythe-squadron-303",
+    "title": "Control Box 23",
+    "artist": "The Germ",
+    "tags": [
+      "acid techno",
+      "acid",
+      "techno",
+      "2000s",
+      "underground"
+    ],
+    "description": "“Control Box 23” by The Germ is an example of raw, acid‑driven techno released on the Scythe Squadron 303 label series. Characterized by its punishing TB‑303 lines, stark rhythm programming, and severe club energy, it reflects the stripped-down intensity of early 2000s acid techno warehouse sets.",
+    "releaseYear": 2002,
+    "label": "Scythe Squadron 303 / Scythe Squadron Exclusive",
+    "album": "High In Chicago EP (various artists)",
+    "country": "UK (label)",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Acid Techno",
+    "aliases": [],
+    "chartInfo": "Obscure underground vinyl release; circulated via DJs and collectors specializing in acid tech.",
+    "synths": [
+      "Roland TB‑303",
+      "TR‑909 samples",
+      "analog modular sounds"
+    ],
+    "drums": "Minimal acid patterns, rigid 4/4 kick, tight claps, hypnotic percussion",
+    "influences": [
+      "Hardfloor",
+      "Chris Liberator",
+      "Radial"
+    ],
+    "genre": "Techno",
+    "subgenre": "Acid Techno",
+    "youtube": [
+      "https://www.youtube.com/watch?v=W5MCVYSYkU8"
+    ]
+  },
+  {
+    "id": "formic-acid-eternia",
+    "title": "Eternia",
+    "artist": "Formic Acid",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1995",
+      "German",
+      "cybertrance"
+    ],
+    "description": "“Eternia” by Formic Acid is an acid‑driven hard trance classic from 1995, released on labels including Cybertronic Records and ZYX Music. Featuring emotive acid melodies, hypnotic rhythms, and signature vocal samples—including a shouted “ETERNIA!!!”—it became a standout on the German trance scene and retains cult status among early rave revivalists.",
+    "releaseYear": 1995,
+    "label": "Cybertronic Records / ZYX Music",
+    "album": "Eternia EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Kai Mac Donald"
+    ],
+    "chartInfo": "Underground anthem of mid‑90s acid‑hard trance, frequently featured in mix compilations like *Trancemaster X*.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus A",
+      "Akai S3000"
+    ],
+    "drums": "Driving 4/4 kick, acid percussion, gated snares, vocal sample drops",
+    "influences": [
+      "Kai Tracid",
+      "Hardfloor",
+      "MFS trance scene"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=EmKw_LR6kP4"
+    ]
+  },
+  {
+    "id": "solarplex-we-are-terminate",
+    "title": "We Are Terminate",
+    "artist": "Solarplex",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1990s",
+      "German",
+      "underground"
+    ],
+    "description": "“We Are Terminate” by Solarplex is a hard‑trance track steeped in acidic energy and dark, pulsating rhythm. Officially released in **1996** on Flying Beam Records, it combines raw TB‑303 lines, crunchy synth drives, and atmospheric build‑ups emblematic of mid‑90s German hard trance.",
+    "releaseYear": 1996,
+    "label": "Flying Beam Records",
+    "album": "N/A",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Underground vinyl release; respected within European acid/hard trance collectors and DJs.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus A"
+    ],
+    "drums": "Punchy 4/4 kicks, acid percussion fills, gated snares",
+    "influences": [
+      "Hardfloor",
+      "Kai Tracid",
+      "Mauro Picotto"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Hard Trance",
+    "youtube": []
+  },
+  {
+    "id": "skeet-bernoullis-equation",
+    "title": "Bernoulli’s Equation",
+    "artist": "Skeet",
+    "tags": [
+      "acid trance",
+      "1997",
+      "underground",
+      "tech trance"
+    ],
+    "description": "“Bernoulli’s Equation” by Skeet is a quintessential acid trance track from 1997. Released on the *Incubation EP* on acid‑focused labels, it features a hallmark rolling TB‑303 acid line, hypnotic synth layering, and driving 4/4 rhythms that typify late‑90s underground trance sounds.",
+    "releaseYear": 1997,
+    "label": "Incubation Records / DJ Skeet",
+    "album": "Incubation EP",
+    "country": "Unknown",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Skeet"
+    ],
+    "chartInfo": "Obscure vinyl EP release; circulated in underground trance collections.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus",
+      "Novation"
+    ],
+    "drums": "4/4 kick, acid snare hits, hypnotic percussive loops",
+    "influences": [
+      "Hardfloor",
+      "Christopher Lawrence",
+      "Miro"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": []
+  },
+  {
+    "id": "tranceplant-active-misuse",
+    "title": "Active Misuse",
+    "artist": "Tranceplant",
+    "tags": [
+      "acid trance",
+      "tech-trance",
+      "hard trance",
+      "1990s",
+      "underground"
+    ],
+    "description": "“Active Misuse” by Tranceplant was released in 1996 alongside “Dying Planet” on Lunacy Records (catalog LOON 9611). This acid‑laden trance track features pounding TB‑303 sequences, rigid 4/4 beats, and stripped-down layers—hallmarks of mid‑90s underground UK acid trance. It thrives on its minimalism and acid energy, making it a staple in obscure trance vinyl collections.",
+    "releaseYear": 1996,
+    "label": "Lunacy Records (Tranceplant release, LOON 9611)",
+    "album": "Dying Planet / Active Misuse 12\"",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Tech Trance",
+    "aliases": [],
+    "chartInfo": "Underground vinyl-only release; circulated via collectors and DJs in acid/trance scenes.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B"
+    ],
+    "drums": "Hard 4/4 kick, acid percussion fills, stark snare patterns",
+    "influences": [
+      "Hardfloor",
+      "Mauro Picotto",
+      "Proteus (UK rave acid)"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Tech Trance",
+    "youtube": []
+  },
+  {
+    "id": "rmb-reality-commander-tom-remix",
+    "title": "Reality (Commander Tom Remix)",
+    "artist": "RMB",
+    "tags": [
+      "acid trance",
+      "tech trance",
+      "1990s",
+      "1996",
+      "remix",
+      "German"
+    ],
+    "description": "This epic remix of RMB’s “Reality” was crafted by Commander Tom and released in 1996. The remix transforms the original into a high‑energy acid‑trance anthem, layering TB‑303 acid lines over punchy beats and atmospheric pads. Its sweeping breakdowns and driving rhythm captured the mid‑90s German rave sound and solidified its status as a cult classic.",
+    "releaseYear": 1996,
+    "label": "Urban / X‑Traxx",
+    "album": "Reality (Remixes)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "RMB"
+    ],
+    "chartInfo": "Underground favorite among trance/Rave DJs; featured on vinyl and CD singles of the remixes.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B",
+      "Roland JP‑8000"
+    ],
+    "drums": "Driving kick, crisp hi‑hats, acid percussion fills, gated snares",
+    "influences": [
+      "Commander Tom",
+      "Frank E‑Time",
+      "Hardfloor"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=F4ajokcjwmc"
+    ]
+  },
+  {
+    "id": "dj-mishka-fifth-element",
+    "title": "Fifth Element",
+    "artist": "DJ Mishka",
+    "tags": [
+      "acid trance",
+      "goa trance",
+      "1990s",
+      "UK",
+      "underground"
+    ],
+    "description": "“Fifth Element” by DJ Mishka is an archetypal UK acid trance track released in 1998. Known for its soaring TB‑303 acid lines, cerebral pads, and hypnotic progression, it captures the late‑90s European trance sound with gyroscopic energy and emotional build. The original and its Skyscraper Mix became cult favorites in underground trance circles.",
+    "releaseYear": 1998,
+    "label": "Voltage Controlled Frequencies (VCF)",
+    "album": "Fifth Element 12\" single",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Acid Trance",
+    "aliases": [],
+    "chartInfo": "Released as a white‑label 12\" in 1998 via VCF 011; the original and Skyscraper Mix circulated widely in UK acid trance sets.",
+    "synths": [
+      "Roland TB‑303",
+      "Roland Juno‑106",
+      "Access Virus B"
+    ],
+    "drums": "Driving kick, acid percussion fills, hi‑hats, rhythmic breaks",
+    "influences": [
+      "Hardfloor",
+      "Goa Trance pioneers",
+      "Voltage Controlled Frequencies labelmates"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=-7hnbZMI3e8"
+    ]
+  },
+  {
+    "id": "pablo-gargano-definition-of-a-track-david-craig-remix",
+    "title": "Definition of a Track (David Craig Remix)",
+    "artist": "Pablo Gargano",
+    "tags": [
+      "acid trance",
+      "tech trance",
+      "1990s",
+      "UK",
+      "remix"
+    ],
+    "description": "Released in 1996, 'Definition of a Track (David Craig Remix)' takes Pablo Gargano's original and drives it deeper into acid territory with hypnotic 303 lines, heavier kick programming, and a darker, stripped-down feel. A cult favorite in the UK underground scene, it was released via Eve Records and remains a key example of mid-90s acid trance remix culture.",
+    "releaseYear": 1996,
+    "label": "Eve Records",
+    "album": "Definition of a Track 12\" single",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Popular in UK acid trance DJ sets and featured on multiple vinyl-only remix EPs during the mid-90s.",
+    "synths": [
+      "Roland TB-303",
+      "Access Virus A",
+      "Juno-106"
+    ],
+    "drums": "4/4 kick, gated snares, acid break loops, echoing claps",
+    "influences": [
+      "Tony De Vit",
+      "Commander Tom",
+      "Kai Tracid"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Tech Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=oY56-oopeDU"
+    ]
+  },
+  {
+    "id": "bass-driver-another-world-timeless-mix",
+    "title": "Another World (Timeless Mix)",
+    "artist": "Bass Driver",
+    "tags": [
+      "acid trance",
+      "1990s",
+      "1997",
+      "underground",
+      "Timeless Mix"
+    ],
+    "description": "Released in 1997, 'Another World (Timeless Mix)' by Bass Driver is a classic acid-trance cut built around rolling 303 basslines, driving four‑to‑the‑floor beats, and euphoric synth arpeggios. It epitomizes late-90s underground trance, popular in mix compilations and DJ sets across Europe.",
+    "releaseYear": 1997,
+    "label": "Rubble / Trancemaster X",
+    "album": "Trancemaster X (Natural Energizer) compilation & 12\" single",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Underground favorite featured on Trancemaster compilations and acid trance collections.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B"
+    ],
+    "drums": "Steady kick, rolling acid percussion, arpeggiated snares, echoing hats",
+    "influences": [
+      "Hardfloor",
+      "MFS Sound",
+      "early German trance labels"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=2q68ETzYIME"
+    ]
+  },
+  {
+    "id": "prezioso-raise-your-power",
+    "title": "Raise Your Power",
+    "artist": "Prezioso",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1990s",
+      "1997",
+      "Italian"
+    ],
+    "description": "Released in 1997, “Raise Your Power” by Prezioso is an energetic acid trance anthem featuring rippling TB‑303 leads, driving 4/4 kicks, and euphoric synth stabs. Issued on Trance Communications / Red Records (TRC‑R003), it became a well‑known track within European trance circuits and remains a nostalgic highlight in mid‑90s underground dance music.",
+    "releaseYear": 1997,
+    "label": "Trance Communications / Red Records",
+    "album": "Raise Your Power 12\" single",
+    "country": "Italy",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Giorgio Prezioso",
+      "Andrea Prezioso"
+    ],
+    "chartInfo": "Vinyl-only release; highly circulated in European trance DJ sets and compilation labels.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus",
+      "Juno‑106"
+    ],
+    "drums": "Pounding kick, gated snares, acid percussion patterns, echoing hats",
+    "influences": [
+      "Hardfloor",
+      "Hard Trance labels",
+      "European underground trance"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Acid Trance",
+      "Hard Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=xRH1T5kvJeQ"
+    ]
+  },
+  {
+    "id": "butsch-move",
+    "title": "Move",
+    "artist": "Butsch",
+    "tags": [
+      "techno",
+      "1993",
+      "underground",
+      "Global Ambition"
+    ],
+    "description": "“Move” (credited as Butsch – ‘Global Transfer’) is a raw, early-’90s techno track released in 1993 on the German label Global Ambition (Global Transfer EP). Known for its gritty analog textures, pounding kick, and stripped-down production, it's a classic of obscure vinyl techno pressing favored by underground DJs and early rave circuits.",
+    "releaseYear": 1993,
+    "label": "Global Ambition (Global Transfer EP)",
+    "album": "Global Transfer EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Techno",
+    "aliases": [],
+    "chartInfo": "Obscure vinyl-only release; featured on the 1993 Global Transfer EP and circulated within underground electronic circles.",
+    "synths": [
+      "Roland SH-101",
+      "TR-909 samples",
+      "Analog textures"
+    ],
+    "drums": "Pounding 4/4 kick, minimal hi-hats, acid-tinged percussion loops",
+    "influences": [
+      "German early ’90s techno",
+      "Global Ambition label style"
+    ],
+    "genre": "Techno",
+    "subgenre": "Underground Techno",
+    "youtube": [
+      "https://www.youtube.com/watch?v=ni0gJhv3gQk"
+    ]
+  },
+  {
+    "id": "nostrum-brainchild",
+    "title": "Brainchild",
+    "artist": "Nostrum",
+    "tags": [
+      "hard trance",
+      "acid trance",
+      "1990s",
+      "German",
+      "classic"
+    ],
+    "description": "Released originally in the mid‑1990s, “Brainchild” by Nostrum is a landmark German hard/acid trance track celebrated for its rolling TB‑303 bass lines, euphoric melodies, and driving rhythm. It featured on vinyl singles and prominent remix EPs, becoming a go‑to in underground European trance sets.",
+    "releaseYear": 1996,
+    "label": "Time Unlimited",
+    "album": "Brainchild 12\" / The Remixes EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A cult classic within the hard trance and acid trance community; released as both the original and 1997 remix versions on vinyl and remix EPs.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus A",
+      "Novation Supernova"
+    ],
+    "drums": "Steady kick, acid percussion loops, gated snares, subtle cymbal rushes",
+    "influences": [
+      "Hardfloor",
+      "Time Unlimited artists",
+      "90s German hard trance"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Hard Trance",
+      "Acid Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=1kVsblFrI9o"
+    ]
+  },
+  {
+    "id": "proto-type-the-process-pro-mix",
+    "title": "The Process (Pro‑Mix)",
+    "artist": "Proto‑Type",
+    "tags": [
+      "acid trance",
+      "progressive trance",
+      "1997",
+      "German",
+      "Pro‑Mix"
+    ],
+    "description": "Released in November 1997 on Future Recordings (FUTURE 016‑12), 'The Process (Pro‑Mix)' by Proto‑Type is a dreamy acid-trance bouncer crafted by producers Kai and Torben. Known for its floaty pads, rolling acid lines, and hypnotic groove, it became a standout of the German trance underground in the late ’90s.",
+    "releaseYear": 1997,
+    "label": "Future Recordings",
+    "album": "The Process 12\" single",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Vinyl-only release; featured in techno/trance DJ sets and Acid trance compilations.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus A",
+      "Roland Juno‑106"
+    ],
+    "drums": "Pulsing kick, acid percussion loops, lush pads, trance arpeggios",
+    "influences": [
+      "Kai Tracid",
+      "Cosmic Baby",
+      "MFS label sound"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=xGAq-VsYtgo"
+    ]
+  },
+  {
+    "id": "en-garde-enfant-terrible-cruel-noise-mix",
+    "title": "Enfant Terrible (Cruel Noise Mix)",
+    "artist": "En Garde",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1990s",
+      "German",
+      "Cruel Noise Mix"
+    ],
+    "description": "Released in 1994, En Garde's 'Enfant Terrible' (Cruel Noise Mix) is a high‑energy acid trance track driven by sharp TB‑303 lines, pounding kicks, and aggressive synth stabs. A cult favorite appearing on compilations like *Cosmic Cubes – A Cosmic Trance Compilation Vol. I* and *Ravermeister Classics*, it embodies mid‑90s German acid‑trance style.",
+    "releaseYear": 1994,
+    "label": "Goldfinger / SPV",
+    "album": "Enfant Terrible 12\" single",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Included on major European trance compilations of the era; multiple mix versions circulated on vinyl.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B"
+    ],
+    "drums": "Driving 4/4 kick, gated snares, acid percussion, echoing hats",
+    "influences": [
+      "Hardfloor",
+      "DJ Hooligan",
+      "German acid trance labels"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=PAvI3A6TKxA"
+    ]
+  },
+  {
+    "id": "aeon-fx-research-single-edit",
+    "title": "Research (Single Edit)",
+    "artist": "Aeon FX",
+    "tags": [
+      "acid trance",
+      "1990s",
+      "1997",
+      "German",
+      "Single Edit"
+    ],
+    "description": "Released in mid‑1997 on Dos Or Die Recordings (DOS 049) and featured on the German CD maxi and vinyl single, 'Research (Single Edit)' by Aeon FX is a concise, radio‑friendly version of the acid‑trance anthem. Clocking in around 3:48, it preserves the key acid lines and atmospheric pads of the Club Mix while offering a streamlined structure for radio or compilation use.",
+    "releaseYear": 1997,
+    "label": "Dos Or Die Recordings",
+    "album": "Research 12\" single / CD maxi",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Included on German releases of CD maxi and 12″ single; secondary edits circulated on compilations and promo CDs.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus A"
+    ],
+    "drums": "Tight 4/4 kick, gated percussion, acid stabs",
+    "influences": [
+      "Hardfloor",
+      "Kai Tracid",
+      "Dos Or Die label style"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=v9QKjHCpl08"
+    ]
+  },
+  {
+    "id": "triple-concept-tonetwister-matic-mix",
+    "title": "Tonetwister (Matic Mix)",
+    "artist": "Triple Concept",
+    "tags": [
+      "acid trance",
+      "tech trance",
+      "1999",
+      "German",
+      "Matic Mix"
+    ],
+    "description": "Released in 1999 on the German Tetsuo label (TET 065‑12), 'Tonetwister (Matic Mix)' by Triple Concept showcases hypnotic acid hooks and rolling rhythms typical of late‑90s underground trance. Known for its air‑raid siren sample buildup and driving groove, it became a cult classic on German vinyl and mix compilations like Acid Flash Vol. 10.",
+    "releaseYear": 1999,
+    "label": "Tetsuo (TET 065‑12)",
+    "album": "Tonetwister 12\" single",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Vinyl-only release; featured on Acid trance compilations and DJ sets across Europe.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B"
+    ],
+    "drums": "Driving 4/4 kick, acid percussion loops, filter sweeps, siren effects",
+    "influences": [
+      "De La Ray",
+      "Hypetraxx",
+      "Sean Dexter"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=H69FcYQPviA"
+    ]
+  },
+  {
+    "id": "albion-air-palefield-mountain-remix",
+    "title": "Air (Palefield Mountain Remix)",
+    "artist": "Albion",
+    "tags": [
+      "acid trance",
+      "progressive trance",
+      "1998",
+      "UK",
+      "remix"
+    ],
+    "description": "Released in June 1998 on Platipus (PLAT 38), Albion’s “Air (Palefield Mountain Remix)” is a sprawling acid trance epic defined by deep TB‑303 textures, rolling rhythms, and dreamy melodic evolutions. Remixed by Palefield Mountain (Adam Salkeld & Rickard Berg), it became a beloved underground trance journey across the UK and European scene.",
+    "releaseYear": 1998,
+    "label": "Platipus Music (PLAT 38)",
+    "album": "Air 12\" single",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Adam Salkeld & Rickard Berg (Palefield Mountain)"
+    ],
+    "chartInfo": "Underground cult classic; featured on multiple trance mix compilations and blog retrospectives.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B"
+    ],
+    "drums": "Deep 4/4 kick, acid percussion loops, sweeping hi‑hats, spacious cymbals",
+    "influences": [
+      "Platipus label sound",
+      "Jochem Paap (Speedy J)",
+      "early UK progressive trance"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=cZDL2oQhPZk"
+    ]
+  },
+  {
+    "id": "jon-the-dentist-destiny-liberator-remix",
+    "title": "Destiny (Liberator Remix)",
+    "artist": "Jon the Dentist",
+    "tags": [
+      "acid trance",
+      "1990s",
+      "1996",
+      "UK",
+      "Liberator Remix"
+    ],
+    "description": "Released in 1996 as part of the double‑vinyl LP *Pyramid* on TEC (TEC LP24LP), ‘Destiny (Liberator Remix)’ by Jon the Dentist was remixed by Liberator DJs (Guy McAffer). The track is a classic acid-trance cut with sharp TB‑303 lines, layered pads, and driving 4/4 rhythm, widely supported in underground trance and rave circles.",
+    "releaseYear": 1996,
+    "label": "TEC (Pyramid LP, TEC LP24LP)",
+    "album": "Pyramid",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Featured on Pyramid LP and circulated in DJ sets; Liberator remix became a club favorite.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus B"
+    ],
+    "drums": "Punchy kicks, acid percussion loops, gated snares",
+    "influences": [
+      "Chris Liberator",
+      "Guy McAffer",
+      "UK acid trance scene"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Fk8L1JDjR_A"
+    ]
+  },
+  {
+    "id": "acidphase-dioxid",
+    "title": "Dioxid",
+    "artist": "Acidphase",
+    "tags": [
+      "acid trance",
+      "1996",
+      "Germany",
+      "Acidphase"
+    ],
+    "description": "Released in 1996 as part of the *Press* 12″ on the Acidphase label, ‘Dioxid’ is a signature acid‑trance cut featuring bubbling TB‑303 lines, metallic percussion loops, and a hypnotic rolling groove popular in European rave sets.",
+    "releaseYear": 1996,
+    "label": "Acidphase (Press 12″, 1996)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Acidphase – Dioxid"
+    ],
+    "chartInfo": "A cult track in underground acid‑trance circles, frequently included on compilations such as *Acidphase II* and *Trance Acid Experience 2* :contentReference[oaicite:1]{index=1}.",
+    "synths": [
+      "Roland TB‑303",
+      "SH‑101 style acid synths"
+    ],
+    "drums": "Rolled acid percussion, dry kicks, gated claps",
+    "influences": [
+      "German acid‑trance scene",
+      "1990s rave culture"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": []
+  },
+  {
+    "id": "ganesh-crisis-billabong-mix",
+    "title": "Crisis (Billabong Mix)",
+    "artist": "Ganesh",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1995",
+      "UK",
+      "Billabong Mix"
+    ],
+    "description": "Originally released in 1995 on Phoenix Rising (catalog PHX 003), ‘Crisis (Billabong Mix)’ is an acid‑trance/hard‑trance remix produced by Nigma for Billabong Productions. The mix runs at approximately 7:57, featuring deep TB‑303 acid lines, rolling percussion, and high‑energy trance power typical of mid‑90s UK rave sound.",
+    "releaseYear": 1995,
+    "label": "Phoenix Rising (PHX 003)",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "AA1 mix of the 12″ single; alongside ‘The Dentist’s Old Skool Mayhem Mix’ and 'Original M‑Zone & Chris C Mix'—a standout in underground vinyl sets :contentReference[oaicite:1]{index=1}.",
+    "synths": [
+      "Roland TB‑303",
+      "Analog acid synths"
+    ],
+    "drums": "Rolled acid percussion, driving kicks, tight snares",
+    "influences": [
+      "UK acid‑hard trance",
+      "rave sound circa 1995"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Acid Trance",
+      "Hard Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=xeZg5o1JxGI"
+    ]
+  },
+  {
+    "id": "astrobug-cop-show",
+    "title": "Cop Show",
+    "artist": "Astrobug",
+    "tags": [
+      "acid trance",
+      "psy‑trance",
+      "1998",
+      "UK",
+      "Paradigm Shift"
+    ],
+    "description": "Released in 1998 as the A‑side of a Paradigm Shift Recordings 12″ (*Cop Show / Pandora’s Box*), ‘Cop Show’ is an underground acid/psy‑trance cut featuring dry, looping TB‑303 lines, rugged percussion, and a hypnotic groove around 7:30 in length—often played in late‑90s UK sets.",
+    "releaseYear": 1998,
+    "label": "Paradigm Shift Recordings (Para 003)",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Cop Show / Pandora’s Box"
+    ],
+    "chartInfo": "Cult underground classic among acid‑trance and psy‑trance vinyl circles :contentReference[oaicite:1]{index=1}",
+    "synths": [
+      "Roland TB‑303",
+      "analog acid percussion"
+    ],
+    "drums": "Layered acid percussion, driving dry kicks, hi‑hat rolls",
+    "influences": [
+      "UK acid trance",
+      "psy‑trance crossover in the late 1990s"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Acid",
+      "Psy‑Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=UasAK9oEmFo"
+    ]
+  },
+  {
+    "id": "caterpillar-give-me-your-hand",
+    "title": "Give Me Your Hand",
+    "artist": "Caterpillar",
+    "tags": [
+      "acid trance",
+      "1995",
+      "Germany",
+      "Phuture Wax"
+    ],
+    "description": "Released in 1995 on the *How Do You Feel* 12″ (Phuture Wax WAX 006‑6), this track ‘Give Me Your Hand’ is a dark acid‑trance cut featuring squelchy TB‑303 acid lines, metallic percussion loops, and a tight 4/4 groove—it became a fixture in mid‑90s European underground DJ sets.",
+    "releaseYear": 1995,
+    "label": "Phuture Wax (WAX 006‑6)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Included on the *How Do You Feel* 12″ alongside ‘How Do You Feel’ and ‘Lost In 303’, frequently featured in European compilations like United DJs Of America Vol. 5 ([discogs.com](https://www.discogs.com/release/1105549-Caterpillar-How-Do-You-Feel) and master listing) :contentReference[oaicite:1]{index=1}.",
+    "synths": [
+      "Roland TB‑303"
+    ],
+    "drums": "Acid percussion loops, sharp kicks, subtle claps",
+    "influences": [
+      "German acid‑trance scene",
+      "mid‑90s rave culture"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=-XYtZioisXA"
+    ]
+  },
+  {
+    "id": "defcon69-city-x-hard-mix",
+    "title": "City X (Hard Mix)",
+    "artist": "Defcon 69",
+    "tags": [
+      "acid trance",
+      "1996",
+      "Belgium",
+      "Hard Mix"
+    ],
+    "description": "Released in 1996 on the *City X* 12″ (Acid Trance style), the Hard Mix is a raw 4:45 acid‑trance cut featuring sharp TB‑303 lines, driving percussion loops, and a hypnotic groove typical of mid‑90s Belgian acid trance.",
+    "releaseYear": 1996,
+    "label": "Acid Trance / Unknown Belgian label",
+    "album": null,
+    "country": "Belgium",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "City X (Dream Mix)",
+      "City X (Woo Mix)"
+    ],
+    "chartInfo": "The A‑side Hard Mix runs 4:45 and is often cited as a standout acid‑trance variant on the City X release ([discogs.com](https://www.discogs.com/release/590316-Defcon-69-City-X) entry) :contentReference[oaicite:1]{index=1}.",
+    "synths": [
+      "Roland TB‑303"
+    ],
+    "drums": "Acid percussion loops, punchy kicks, repetitive gated hats",
+    "influences": [
+      "1990s Belgian acid‑trance scene",
+      "harder acid remix aesthetics"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": []
+  },
+  {
+    "id": "joshua-ryan-pistolwhip",
+    "title": "Pistolwhip",
+    "artist": "Joshua Ryan",
+    "tags": [
+      "trance",
+      "uplifting trance",
+      "2000",
+      "USA",
+      "classic trance"
+    ],
+    "description": "Originally released in 2000 (sometimes noted as 1999) on NuLife Records, ‘Pistolwhip’ is an uplifting trance anthem featuring driving basslines, rolling percussion, sweeping synth pads, and high‑energy arpeggios—it spawned several remixes and became a fixture in early‑2000s trance sets.",
+    "releaseYear": 2000,
+    "label": "NuLife (USA)",
+    "album": null,
+    "country": "USA",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Way Out West Remix",
+      "James Holden Remix",
+      "Ariel Remix"
+    ],
+    "chartInfo": "Originally issued on vinyl and CD, it featured remixes by Way Out West, James Holden, and Ariel—widely featured in trance compilations and DJ sets :contentReference[oaicite:1]{index=1}.",
+    "synths": [
+      "Roland JP‑8000",
+      "Access Virus",
+      "digital trance synths"
+    ],
+    "drums": "Driving kick‑heavy 4/4, rolling hi‑hats, gated snare fills",
+    "influences": [
+      "classic Uplifting/epic trance style of late‑90s/early‑2000s"
+    ],
+    "genre": "Trance",
+    "subgenre": "Uplifting Trance",
+    "youtube": []
+  },
+  {
+    "id": "atlantis-vs-avatar-fiji",
+    "title": "Fiji",
+    "artist": "Atlantis vs. Avatar (featuring Miriam Stockley)",
+    "tags": [
+      "classic trance",
+      "vocal trance",
+      "ambient trance",
+      "1999",
+      "UK",
+      "USA"
+    ],
+    "description": "Released in 1999 by Atlantis vs. Avatar, ‘Fiji’ is a lush, emotional trance anthem featuring the ethereal vocals of Miriam Stockley, known for her work with Adiemus. The track blends sweeping ambient pads, arpeggiated synths, and a rolling four-on-the-floor trance beat to create a cinematic, almost spiritual soundscape. Originally issued by Inferno and Subterania, it quickly became a favorite in progressive and vocal trance circles. ‘Fiji’ gained further exposure through Tiësto’s *Magik Five: Heaven Beyond* compilation and was widely remixed by artists like Lange and Binary Finary, helping it become a definitive track of the late 1990s trance era.",
+    "releaseYear": 1999,
+    "label": "Subterania / Inferno Records",
+    "album": null,
+    "country": "UK / USA",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Atlantis – Fiji",
+      "Atlantis vs Avatar – Fiji"
+    ],
+    "chartInfo": "Featured on *Magik Five* by Tiësto and received extensive airplay on trance compilations. Charted modestly in the UK Singles Chart upon re-release with the Lange Remix in 2001.",
+    "synths": [
+      "Access Virus",
+      "JP‑8000",
+      "Korg Trinity",
+      "ambient vocal pads"
+    ],
+    "drums": "Classic uplifting trance kicks, subtle snare fills, ambient percussion layers",
+    "influences": [
+      "Adiemus vocal style",
+      "late‑90s UK progressive and vocal trance scene"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Vocal",
+      "Ambient Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=9ydVtYAftbM"
+    ]
+  },
+  {
+    "id": "audience-flow-the-mind-is-different-club-attack",
+    "title": "The Mind Is Different (Club Attack)",
+    "artist": "Audience Flow",
+    "tags": [
+      "acid hard trance",
+      "1999",
+      "Germany",
+      "Club Attack Mix"
+    ],
+    "description": "Released in 1999 on the *The Mind Is Different / Take Me Away* vinyl single (Soundtraxx Music Production SMP2‑18), the Club Attack Mix delivers tight acid-trance energy. At around 6:04 in length, it’s driven by aggressive rolling TB‑303 patterns, hard-hitting trance kicks, and trance‑style stabs. Frequently featured in underground DJ sets in German club circuits of the late ’90s.",
+    "releaseYear": 1999,
+    "label": "Soundtraxx Music Production (SMP2‑18)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "The Mind Is Different / Take Me Away 12″"
+    ],
+    "chartInfo": "A‑side Club Attack Mix of vinyl single; also issued in Extended Mix (~6:31) and paired with 'Take Me Away (Club Mix)' on the B‑side ([discogs.com release entry])",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus-style synth pads"
+    ],
+    "drums": "Punchy 4/4 kicks, gated hi‑hats, rolling trance percussion",
+    "influences": [
+      "German acid/hard trance of late‑1990s",
+      "club‑focused trance production"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=8cNNlIH0sTA"
+    ]
+  },
+  {
+    "id": "cyberotic-night-in-istanbul",
+    "title": "Night in Istanbul",
+    "artist": "Cyberotic",
+    "tags": [
+      "acid trance",
+      "1994",
+      "Germany",
+      "Cyberotic"
+    ],
+    "description": "Originally released in 1994 on the *Passions EP* by Cyberotic, “Night in Istanbul” is a signature acid‑trance instrumental featuring squelchy TB‑303 lines, metallic acid percussion, and a hypnotic rolling groove at roughly 5:46. It reflects the raw energy of mid‑90s German acid trance and became a cult favorite in underground sets.",
+    "releaseYear": 1994,
+    "label": "Cyberotic (Passions EP, 1994)",
+    "album": "Passions EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A‑side of the *Passions EP* (track A1) alongside ‘Rising Sun’ and ‘130 BPM Drive’—widely circulated in mid‑90s acid sets and clubnight compilations ([discogs.com](https://www.discogs.com/release/210756-Cyberotic-Passions-EP) ).",
+    "synths": [
+      "Roland TB‑303",
+      "classic 1990s acid percussion synthesis"
+    ],
+    "drums": "Dry acid percussion loops, tight kicks, minimal hi‑hat rolls",
+    "influences": [
+      "German 90s acid trance scene",
+      "early rave minimalism"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=ppE72mLe6SU"
+    ]
+  },
+  {
+    "id": "dj-mishka-fifth-element-skyscraper-mix",
+    "title": "Fifth Element (Skyscraper Mix)",
+    "artist": "DJ Mishka",
+    "tags": [
+      "acid trance",
+      "1998",
+      "UK",
+      "Skyscraper Mix"
+    ],
+    "description": "Originally released in 1998 by DJ Mishka on Voltage Controlled Frequencies (VCF‑011, UK white label), the Skyscraper Mix of 'Fifth Element' delivers a searing acid‑trance experience. Clocking in at around 7:25, it layers TB‑303 acid lines over hypnotic percussion, sweeping pads, and trance‑style arpeggios, typical of late‑90s UK underground sound.",
+    "releaseYear": 1998,
+    "label": "Voltage Controlled Frequencies (VCF‑011)",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Fifth Element (Original Mix)",
+      "Fifth Element (Skyscraper Mix)"
+    ],
+    "chartInfo": "Issued on a UK white‑label 12″ along with the Original Mix; became a cult acid‑trance cut in underground DJ sets.",
+    "synths": [
+      "Roland TB‑303",
+      "Access Virus‑style trance synths"
+    ],
+    "drums": "Driving kicks, acid percussion loops, tight hi‑hat rolls",
+    "influences": [
+      "UK acid‑trance and rave aesthetic of the late ’90s"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=oXAPv_wkSX4"
+    ]
+  },
+  {
+    "id": "ppk-reload-radio-edit",
+    "title": "Reload (Radio Edit)",
+    "artist": "PPK",
+    "tags": [
+      "trance",
+      "radio edit",
+      "2002",
+      "Russian trance",
+      "hit single"
+    ],
+    "description": "Released in 2002, ‘Reload (Radio Edit)’ is the single version of PPK’s reinterpretation of 'Zodiak' by Latvian band Zodiaks. Clocking in at approximately 3:29, this concise edit became a minor UK chart hit (peaking at #39), epitomizing accessible Russian trance with memorable melodies and polished production. The group PPK—named after its original members Sergey Pimenov, Alexander Polyakov, and Roman Korzhov—rose to international prominence following their earlier single ‘ResuRection’.",
+    "releaseYear": 2002,
+    "label": "Perfecto / PPK Management (iRecords)",
+    "album": "Russian Trance: Formation",
+    "country": "Russia",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Sergey Pimenov",
+      "Alexander Polyakov",
+      "Roman Korzhov"
+    ],
+    "chartInfo": "Peaked at #39 on the UK Singles Chart following the international success of “ResuRection” ([en.wikipedia.org](https://en.wikipedia.org/wiki/PPK_%28duo%29))",
+    "synths": [
+      "Digital trance synths inspired by 'Zodiak' theme"
+    ],
+    "drums": "Clean four-on‑the‑floor kicks, subtle hi‑hats, vocal‑style patterns",
+    "influences": [
+      "Latvian electronic melody 'Zodiak', Russian trance style",
+      "late‑90s/early‑00s trance"
+    ],
+    "genre": "Trance",
+    "subgenre": "Melodic Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=ZsrB457pfFo"
+    ]
+  },
+  {
+    "id": "wawa-thomas-gold-latin-thing-dub-mix",
+    "title": "Latin Thing (Thomas Gold Dub Mix)",
+    "artist": "Wawa & Thomas Gold",
+    "tags": [
+      "house",
+      "electro house",
+      "2007",
+      "Haiti Groove",
+      "Thomas Gold remix"
+    ],
+    "description": "Released in September 2007 on Haiti Groove Recordings, ‘Latin Thing (Thomas Gold Dub Mix)’ is a high‑energy electro house rework produced by Thomas Gold in collaboration with Wawa. Running around 7:18–7:31, it layers Latin‑flavored rhythms, punchy house beats, and grooving synth lines, typical of mid‑2000s electro house styles.",
+    "releaseYear": 2007,
+    "label": "Haiti Groove Recordings (HGR‑018)",
+    "album": null,
+    "country": "Germany / International",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "Thomas Gold (Beat Riders, Dee‑Luxe, Frank Knebel, Frankk, Level K, Plastic)",
+      "Wawa"
+    ],
+    "chartInfo": "Popular in the European house club scene; featured in DJ sets and Beatport electro house charts.",
+    "synths": [
+      "Digital house synths",
+      "Latin percussive samples"
+    ],
+    "drums": "Punchy four‑on‑the‑floor kicks, layered percussion, offbeat hi‑hats",
+    "influences": [
+      "Latin house style",
+      "mid‑2000s electro house trends"
+    ],
+    "genre": "House",
+    "subgenre": "Electro House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=YlheFu8LH9A"
+    ]
+  },
+  {
+    "id": "latin-thing-latin-intruder-mix",
+    "title": "Latin Thing (Latin Intruder Mix)",
+    "artist": "Latin Thing",
+    "tags": [
+      "house",
+      "Latin house",
+      "1995",
+      "electro house",
+      "Latin Intruder Mix"
+    ],
+    "description": "Released in 1995 on Faze 2 as part of a 12″ promo, ‘Latin Thing (Latin Intruder Mix)’ is a percussion-heavy Latin house track that blends tribal rhythms with punchy house grooves and vocal loops. This version stands out with its more stripped-down club format, running approximately 5:00. It was circulated among DJs in white-label form and gained underground popularity during the mid-’90s club scene.",
+    "releaseYear": 1995,
+    "label": "Faze 2 (Promo 12″)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "The Latin Intruders",
+      "Latin Thing"
+    ],
+    "chartInfo": "Released as a 12″ white label promo including the Alive Mix and Eat Me Edit; gained popularity in Latin and tribal house DJ sets.",
+    "synths": [
+      "Digital tribal synths",
+      "Latin percussion stabs"
+    ],
+    "drums": "Four-on-the-floor kicks, tribal percussion loops, minimal hats",
+    "influences": [
+      "Latin house fusion",
+      "tribal house",
+      "1990s club cuts"
+    ],
+    "genre": "House",
+    "subgenre": "Latin House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=wIN9XCXNlkU"
+    ]
+  },
+  {
+    "id": "king-booo-tunes-since-89",
+    "title": "Tunes Since '89",
+    "artist": "KING BOOO!",
+    "tags": [
+      "UK garage",
+      "rave revival",
+      "2024",
+      "London",
+      "4×4 garage"
+    ],
+    "description": "Released in June 2024 on Attention Deficit Recordings, 'Tunes Since '89' is a UK‑garage track steeped in nostalgia—employing emotive vocal chops, glittery piano stabs, warm pads, and a punchy 4×4 garage groove. The track pays homage to classic late‑’80s/early‑’90s UK rave culture while remaining contemporary in production, widely featured across independent UKG blogs and DJ sets.",
+    "releaseYear": 2024,
+    "label": "Attention Deficit Recordings",
+    "album": "Tunes Since '89 (Single)",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Garage",
+    "aliases": [
+      "KING BOOO!"
+    ],
+    "chartInfo": "Released via Bandcamp and SoundCloud in mid-2024; featured heavily in modern UKG DJ circuits and editorial coverage.",
+    "synths": [
+      "Digital UKG piano stabs",
+      "warm ambient pads"
+    ],
+    "drums": "Punchy 4‑on‑the‑floor garage beats with shuffled hi‑hats",
+    "influences": [
+      "late‑’80s UK rave piano house",
+      "early 4×4 garage",
+      "modern melodic garage"
+    ],
+    "genre": "Garage",
+    "subgenre": "UK Garage",
+    "youtube": [
+      "https://www.youtube.com/watch?v=m47I7JiNU1k"
+    ]
+  },
+  {
+    "id": "radiotrance-vostok",
+    "title": "Vostok (Vostok 5)",
+    "artist": "Radiotrance (DJ Cosmonaut & DJ Zajats)",
+    "tags": [
+      "goa trance",
+      "1997",
+      "Russia",
+      "classic trance"
+    ],
+    "description": "A standout Goa‑trance journey released in 1997 on *The Russian EP* (Transient Records), ‘Vostok’—often labeled ‘Vostok 5’—features hypnotic melodic sequencing, cosmic arpeggios, and sweeping synth work over roughly 8 minutes. A seminal Russian Goa track and key emergence for Eastern Bloc trance sound.",
+    "releaseYear": 1997,
+    "label": "Transient Records (TRA032)",
+    "album": "The Russian EP",
+    "country": "Russia / UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Vostok 5"
+    ],
+    "chartInfo": "Track A2 on *The Russian EP*; gained cult status among Goa communities and was featured in early UK Goa compilations.",
+    "synths": [
+      "Classic Goa arps",
+      "digital trance pads",
+      "acid bass sequences"
+    ],
+    "drums": "Driving kick, layered percussion, off‑beat hats with rhythmic pulses",
+    "influences": [
+      "1990s Goa trance pioneers",
+      "Eastern European trance sound"
+    ],
+    "genre": "Trance",
+    "subgenre": "Goa Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=oF8nDt7rFRI"
+    ]
+  },
+  {
+    "id": "nostrum-trance-on-ecstasy",
+    "title": "Trance On Ecstasy",
+    "artist": "Nostrum",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1994",
+      "Germany",
+      "Time Unlimited"
+    ],
+    "description": "Released in 1994 on Time Unlimited, ‘Trance On Ecstasy’ is one of Nostrum’s earliest and most iconic acid trance anthems. With cascading TB‑303 acid lines, euphoric leads, and hard, rolling percussion, the track captures the peak energy of the early European trance movement. It became a staple in mid-’90s German underground rave culture and helped define Nostrum’s signature melodic-acid sound.",
+    "releaseYear": 1994,
+    "label": "Time Unlimited (TIME 004)",
+    "album": "Trance On Ecstasy (12\")",
+    "country": "Germany",
+    "artistBorn": "Bernd Augustinski",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "DJ Nostrum"
+    ],
+    "chartInfo": "Featured on numerous German trance compilations in the mid-'90s; revered as a foundational acid trance release from Time Unlimited.",
+    "synths": [
+      "Roland TB‑303",
+      "JP‑8000",
+      "Access Virus"
+    ],
+    "drums": "Relentless kick drum, acid percussion loops, gated snares, hi-hat flutters",
+    "influences": [
+      "early German acid trance",
+      "European rave scene",
+      "Goa-adjacent melodic trance"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Acid Trance",
+      "Hard Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=bSzdHKynQks"
+    ]
+  },
+  {
+    "id": "dj-choci-strange-when-youre-twisted-3ofi-mix",
+    "title": "Strange When You’re Twisted (3OFI Mix)",
+    "artist": "DJ Choci",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1998",
+      "UK",
+      "3OFI Mix"
+    ],
+    "description": "Released in 1998 on Cannon Records (catalog CANNON6), the *3OFI Mix* of “Strange When You’re Twisted” is an aggressive acid‑spin on trance and hard house. Wrapped around rugged 303 acid stabs, rolling kicks and hypnotic trance motifs, this version stands out in DJ Choci’s discography and in late‑90s UK underground sets.",
+    "releaseYear": 1998,
+    "label": "Cannon Records (CANNON6)",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A‑side 12″ mix commonly circulated in UK club and acid‑trance circles; paired with the Jon Doe Remix on the release :contentReference[oaicite:1]{index=1}",
+    "synths": [
+      "Roland TB‑303 acid lines",
+      "digital trance synth stabs"
+    ],
+    "drums": "Driving hard 4/4 kicks, acid percussion loops, crisp hi‑hats",
+    "influences": [
+      "UK acid‑house/trance crossover",
+      "late‑90s acid‑trance style"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Acid",
+      "Hard Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=TJejR1Lwylo"
+    ]
+  },
+  {
+    "id": "legacy-the-rain",
+    "title": "The Rain",
+    "artist": "Legacy",
+    "tags": [
+      "trance",
+      "1997",
+      "Germany",
+      "Legacy"
+    ],
+    "description": "Released in 1997 on Reef Recordings (catalog REEF001‑6), ‘The Rain’ by German trance act Legacy is a mid‑tempo classic blending dreamy pads, vocals, and melodic trance motifs. Clocking around 6–7 minutes, the track exemplifies late‑’90s chilled trance and remains a cult favorite in European trance archives.",
+    "releaseYear": 1997,
+    "label": "Reef Recordings (REEF001‑6)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A standalone single; distributed in Germany and Eastern Europe, frequently featured in vintage trance DJ sets.",
+    "synths": [
+      "Warm ambient pads",
+      "vocal synth textures"
+    ],
+    "drums": "Gentle kick‑based 4/4 beat with soft hi‑hats and emotional percussion",
+    "influences": [
+      "German melodic trance",
+      "late‑90s chill‑trance aesthetics"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Melodic",
+      "Chill Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=D7fLbnpK9i0"
+    ]
+  },
+  {
+    "id": "tb-tuner-in-303-we-trust",
+    "title": "In 303 We Trust",
+    "artist": "TB‑Tuner",
+    "tags": [
+      "acid trance",
+      "1997",
+      "Germany",
+      "TB‑Tuner"
+    ],
+    "description": "Released in 1997 on the 12″ *After Works* (Acid Trance Germany), ‘In 303 We Trust’ is a definitive acid‑trance bomb featuring squelchy TB‑303 basslines, stripped-down percussion loops, and a hypnotic groove of around 4:43. A cult favorite in late‑90s underground acid‑trance sets, the track has seen steady circulations in DJ mixes and archival playlists.",
+    "releaseYear": 1997,
+    "label": "Acid Trance Germany (After Works 12″)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "Appears as track B2 on the *After Works* vinyl; widely referenced in trance archives and acid‑trance collections.",
+    "synths": [
+      "Roland TB‑303 acid bass",
+      "analog acid percussion"
+    ],
+    "drums": "Minimal kicks, acid percussion loops, simple hi‑hat pulse",
+    "influences": [
+      "German acid‑trance style of the mid‑1990s",
+      "TB‑303-driven grooves"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=X7apHGkXnIw"
+    ]
+  },
+  {
+    "id": "rezoid-again",
+    "title": "Again",
+    "artist": "RezoïD",
+    "tags": [
+      "acid trance",
+      "1994",
+      "Belgium",
+      "RezoïD"
+    ],
+    "description": "Released in 1994 on the *Total Attack* 12″ (Dance Opera DO 383), ‘Again’ is a blistering acid‑trance cut featuring squelchy TB‑303 basslines, resonant acid percussion, and a hypnotic driving groove around 5:33. It captures the raw energy of mid‑’90s Belgian trance and remains a cult track in underground DJ circles.",
+    "releaseYear": 1994,
+    "label": "Dance Opera (DO 383)",
+    "album": "Total Attack 12″",
+    "country": "Belgium",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Eric Beysens",
+      "Kris Luyckx",
+      "D.A. Project",
+      "Dream Frequence",
+      "Pressure Generator 1"
+    ],
+    "chartInfo": "B‑side of *Total Attack* release (A‑side “Total Attack (On Trance)”); frequently featured in archival acid‑trance sets.",
+    "synths": [
+      "Roland TB‑303",
+      "analog acid percussion synthesis"
+    ],
+    "drums": "Driving kick‑heavy 4/4 beat, acid percussion loops, minimal hats",
+    "influences": [
+      "Belgian acid‑trance style",
+      "mid‑’90s rave sound"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=jECY_c6dGq0"
+    ]
+  },
+  {
+    "id": "creambase1-fiddle2003-bellinibrothers-radio-cut",
+    "title": "Fiddle 2003 (Bellini Brothers Radio Cut)",
+    "artist": "Creambase 1",
+    "tags": [
+      "electro house",
+      "2003",
+      "Germany",
+      "Bellini Brothers remix",
+      "Radio Cut"
+    ],
+    "description": "Released in September 2003 on Gang Go Music/Kontor (catalog PRO4140/GG072), ‘Fiddle 2003 (Bellini Brothers Radio Cut)’ is a high‑energy electro house remix running about 3:30. It blends chopped fiddle samples, pounding house beats, and Brazilian‑flavored percussion—typical of mid‑2000s club radio edits.",
+    "releaseYear": 2003,
+    "label": "Gang Go Music / Kontor Records (PRO4140 / GG072)",
+    "album": "Fiddle 2003 (Single / CD Maxi)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [],
+    "chartInfo": "Featured on *Club Rotation Volume 23* and *Dream Dance 29* compilations; runtime ~3:30 as Radio Cut version ([discogs.com](https://www.discogs.com/master/182434-Creambase-1-Fiddle-2003) ) ",
+    "synths": [
+      "Synth fiddle samples",
+      "digital electro-house synths"
+    ],
+    "drums": "Four‑on‑the‑floor kicks, offbeat percussion loops, percussive stabs",
+    "influences": [
+      "Latin‑flavored house",
+      "mid‑2000s club edits"
+    ],
+    "genre": "House",
+    "subgenre": "Electro House",
+    "youtube": []
+  },
+  {
+    "id": "tiesto-traffic",
+    "title": "Traffic",
+    "artist": "Tiësto",
+    "tags": [
+      "trance",
+      "instrumental",
+      "2003",
+      "Dutch trance"
+    ],
+    "description": "Released as a single in October 2003 and later featured on his 2004 album *Just Be*, “Traffic” is a seminal instrumental trance track built around hypnotic rhythmic percussion, minimal melodic stabs, and a driving tempo—widely regarded as Tiësto’s first track to reach #1 on the Dutch charts, and one of the first instrumental trance singles to top a national singles ranking.",
+    "releaseYear": 2003,
+    "label": "Magik Muzik / Black Hole Recordings",
+    "album": "Just Be",
+    "country": "Netherlands",
+    "artistBorn": "Tijs Michiel Verwest (Tiësto)",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Stray Dog",
+      "Steve Forte Rio",
+      "Allure",
+      "VER:WEST",
+      "TST",
+      "Glycerine"
+    ],
+    "chartInfo": "Originally released Oct 8, 2003, peaked #1 in Netherlands — first instrumental trance single to do so in over two decades. B‑side to 'Love Comes Again' single and featured in *Parade of the Athletes* compilation ([turn0search18] [turn0search20] [turn0search2])",
+    "synths": [
+      "Digital trance synth stabs",
+      "rhythmic percussive loops"
+    ],
+    "drums": "Driving four‑on‑the‑floor kick, layered tribal percussion, sparse hats",
+    "influences": [
+      "Minimal techno rhythms",
+      "early 2000s trance",
+      "sample-based electronic structure"
+    ],
+    "genre": "Trance",
+    "subgenre": "Instrumental Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=cSW3y98ObQY"
+    ]
+  },
+  {
+    "id": "dj-zinc-138-trek",
+    "title": "138 Trek",
+    "artist": "DJ Zinc",
+    "tags": [
+      "UK garage",
+      "breakstep",
+      "2000",
+      "UK",
+      "classic"
+    ],
+    "description": "Released in November 2000 (recorded in 1999), “138 Trek” is a pioneering UK garage/breakstep single from British producer DJ Zinc. Built around a stuttering loop from Barry White’s “I’m Gonna Love You Just a Little More Baby”, plus sound bites from *Star Trek*, the track clocks ~5:10 and became a UK No. 27 hit—making it one of the first instrumental garage singles to chart in the mainstream. Its raw, stripped-back rhythm and quirky samples made it a game‑changing fusion of drum & bass, garage, and bass‑step.",
+    "releaseYear": 2000,
+    "label": "True Playaz / Phaze:One",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": "Benjamin Pettit",
+    "artistPrimaryGenre": "UK Garage / Bassline",
+    "aliases": [
+      "Jammin",
+      "Jack Ruby",
+      "Dope Skillz",
+      "The Phantom"
+    ],
+    "chartInfo": "Released 6 November 2000; peaked at UK Singles Chart #27 and UK Dance Chart #1—one of the first non-vocal garage tracks to break top‑40 in the UK :contentReference[oaicite:0]{index=0}.",
+    "synths": [
+      "Breakbeat loop (Barry White)",
+      "minimal garage synth stabs"
+    ],
+    "drums": [
+      "Half‑time 4/4 kick",
+      "syncopated breakstep pattern",
+      "vocal chops and sampled effects"
+    ],
+    "influences": [
+      "Jungle/drum & bass to garage crossover",
+      "UK garage innovation around 140 BPM"
+    ],
+    "genre": "Garage",
+    "subgenre": [
+      "UK Garage",
+      "Breakstep"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=MfmqmrFHJZg"
+    ]
+  },
+  {
+    "id": "drax-amphetamine-original-remaster",
+    "title": "Amphetamine (Original Remaster)",
+    "artist": "Thomas P. Heckmann (Drax Ltd. II)",
+    "tags": [
+      "techno",
+      "acid techno",
+      "peak time techno",
+      "2012 remaster",
+      "German techno"
+    ],
+    "description": "Originally produced in 1994 under the alias Drax Ltd. II, “Amphetamine” became a hallmark of early acid‑techno. This 2012 **Original Remaster** brings enhanced clarity and punch to the original: ruthless TB‑303 acid basslines, industrial EBM‑styled pads, and tight, driving drums in an extended ~6:44 version. The remix preserved the ruthlessly minimal structure while boosting the sound’s intensity and modern relevance. It’s widely regarded as a cornerstone track in the acid‑techno revival of the 2010s, still featured in peak‑time techno sets and retrospective compilations.",
+    "releaseYear": 2012,
+    "label": "AFU Limited / Trope Recordings (AFUltd.31)",
+    "album": "Drax Trilogy Special Final Edition",
+    "country": "Germany",
+    "artistBorn": "Thomas Peter Heckmann",
+    "artistPrimaryGenre": "Techno",
+    "aliases": [
+      "Drax Ltd. II",
+      "Exit 100",
+      "Age",
+      "Silent Breed",
+      "Knarz",
+      "Welt In Scherben"
+    ],
+    "chartInfo": "Remastered for digital re-release in 2012; frequently paired with the Umek Remix and included in Trope’s *The Complete Remixes and Versions 1994–2012* compilation.",
+    "synths": [
+      "Roland TB‑303",
+      "hard analog acid synth textures",
+      "industrial pad layers"
+    ],
+    "drums": [
+      "Punchy techno kick",
+      "acid percussion loops",
+      "layered snare fills and sequenced pulses"
+    ],
+    "influences": [
+      "German industrial and EBM",
+      "mid‑90s acid techno movement",
+      "Drax Trilogy ethos"
+    ],
+    "genre": "Techno",
+    "subgenre": [
+      "Acid",
+      "Peak Time Techno"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=aps-fDmkE1c"
+    ]
+  },
+  {
+    "id": "neuromancer-pennywise",
+    "title": "Pennywise",
+    "artist": "Neuromancer",
+    "tags": [
+      "breakbeat hardcore",
+      "early‑90s",
+      "1992",
+      "UK rave",
+      "classic"
+    ],
+    "description": "Originally released in 1992 on Symphony Sound Records (catalog SYM 003), “Pennywise” by Neuromancer is a fierce breakbeat hardcore anthem. Clocking in at around 5:20, the track layers rolling breakbeats over chopped vocal samples, eerie pads, and iconic movie dialogue (_“They all float down here…”_), blending UK rave aggression with raw sampling energy. You’ll hear mickey finn & bay b kane remix variations later in the ’90s, but the original mix stands as a cornerstone in the early hardcore + breakbeat continuum.",
+    "releaseYear": 1992,
+    "label": "Symphony Sound Records (SYM 003)",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat Hardcore",
+    "aliases": [
+      "Neuromancer (UK)",
+      "Penny‑Wise Remixers"
+    ],
+    "chartInfo": "Originally issued as a UK 12″ single; widely bootlegged and re‑released across hardcore citations and retrospective mixes.",
+    "synths": [
+      "Rave pads",
+      "sample-triggered movie dialogue"
+    ],
+    "drums": [
+      "Hard breakbeats (Amen loops style)",
+      "stuttering vocal chops",
+      "timed reverbed claps"
+    ],
+    "influences": [
+      "1990–'92 UK Madchester/Hardcore rave aesthetic",
+      "heavy sampling culture",
+      "early jungle/drum‑&‑bass crossover"
+    ],
+    "genre": "Breakbeat Hardcore",
+    "subgenre": [
+      "Rave",
+      "Early Hardcore"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=vQFbrzFpDzo"
+    ]
+  },
+  {
+    "id": "liquid-liquid-journey-into-dub",
+    "title": "Liquid Is Liquid (Journey Into Dub)",
+    "artist": "Liquid (Ame & Model)",
+    "tags": [
+      "hardcore",
+      "breakbeat",
+      "1994",
+      "UK",
+      "Red Jerry Dub"
+    ],
+    "description": "Originally released in 1994 on XL Recordings as part of the *Liquid Love* / *Liquid Is Liquid* EPs, “Liquid Is Liquid (Red Jerry’s Epic Journey Into Dub)” is a standout interpretation by Red Jerry. Clocking ≈11:25, this version unfolds into a cosmic breakdown with echo-laden pads, rolling breakbeats, and hypnotic dub atmospherics built over the original hardcore foundation. A staple in 1990s UK rave culture, it bridges hardcore, ambient, and early drum‑&‑bass sensibilities, and has retained lasting prestige in the archival DJ circuit.",
+    "releaseYear": 1994,
+    "label": "XL Recordings (XLT 48 / Liquid Love EP)",
+    "album": "Liquid Love EP",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat Hardcore",
+    "aliases": [
+      "Liquid",
+      "Ame & Model"
+    ],
+    "chartInfo": "Part of *Liquid Love* EP in 1994; Red Jerry’s long-form Journey Into Dub is widely circulated on compilations and trance heritage sets.",
+    "synths": [
+      "Echoing rave pads",
+      "dub-style ambient synths",
+      "hardcore stab variations"
+    ],
+    "drums": [
+      "Rolled breakbeats",
+      "heavy use of delay and reverb",
+      "minimal melodic motifs"
+    ],
+    "influences": [
+      "UK hardcore/dub crossover",
+      "early jungle ambience",
+      "rave-era dub aesthetics"
+    ],
+    "genre": "Breakbeat Hardcore",
+    "subgenre": "Dub-style Rave",
+    "youtube": [
+      "https://www.youtube.com/watch?v=5XRtDFMlazA"
+    ]
+  },
+  {
+    "id": "binary-finary-1998-kay-cee-1999-radio-mix",
+    "title": "1998 (Kay Cee 1999 Radio Mix)",
+    "artist": "Binary Finary",
+    "tags": [
+      "trance",
+      "uplifting trance",
+      "1999",
+      "UK",
+      "Kay Cee Remix"
+    ],
+    "description": "Originally produced as the iconic instrumental “1998” (1997/98), Binary Finary’s *1999 Radio Mix* by Dutch DJ‑producer Kay Cee condenses the epic melody into a tight 3:07 radio format. Crisp arpeggiated leads, dreamy chord pads, and emotional breakdowns give way to a soaring populated climax—all staged against a polished yet urgent tempo (~134 BPM). The Radio Mix brought mainstream accessibility to what was already one of the most beloved trance anthems of its era.",
+    "releaseYear": 1999,
+    "label": "Armada Music (1998 – Remixes)",
+    "album": "1998 – Remixes",
+    "country": "UK / Netherlands",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Binary Finary"
+    ],
+    "chartInfo": "Part of the official *1998 Remixes* release (Armada, 1999), along with Gouryella, Paul van Dyk, and other mixes; streamed widely across radio and trance compilations in late 1999–2000.",
+    "synths": [
+      "Classic uplifting trance arp synths",
+      "dreamy saw‑wave pads"
+    ],
+    "drums": [
+      "Four‑on‑the‑floor kick",
+      "shuffled trance hats",
+      "wide snare rolls"
+    ],
+    "influences": [
+      "Uplifting 90s trance era",
+      "anthemic melodies of early‑2000s",
+      "melodic trance pioneers"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Uplifting",
+      "Anthemic Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=FeYmMPaj5Vc"
+    ]
+  },
+  {
+    "id": "lost-witness-happiness-happening-lange-remix",
+    "title": "Happiness Happening (Lange Remix)",
+    "artist": "Lost Witness",
+    "tags": [
+      "trance",
+      "vocal trance",
+      "1999",
+      "UK",
+      "Lange Remix"
+    ],
+    "description": "Released in early 1999, Lange’s remix of Lost Witness’s *Happiness Happening* transforms the original club classic into a soaring vocal trance anthem. Clocking approximately 7:15 in its extended form, the remix overlays lush, emotional vocals (by Tracey Carmen) atop expansive trance stabs, arpeggiated pads, and driving 138 BPM energy. Lange restructures the track into euphoric build-ups, oceanic breakdowns, and powerful drop sections—with atmospheric risers and shimmering synths that elevate it from vocal-house into trance legend. It received major club play across Europe and was frequently featured on trance compilations and radio playlists.",
+    "releaseYear": 1999,
+    "label": "Armada Music / Ministry of Sound (1999 remixes)",
+    "album": "Remixes Volume (Various releases)",
+    "country": "UK",
+    "artistBorn": "Simon Paul (Lost Witness)",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Dusk Til Dawn",
+      "The Eden Project"
+    ],
+    "chartInfo": "Remix of the original single (UK #18 in 1999), widely played across UK and European trance radio. Liebti track in late‑90s trance compilations and A State of Trance Classics sets.",
+    "synths": [
+      "Atmospheric trance pads",
+      "classic 90s trance arps",
+      "vocal-driven synth waves"
+    ],
+    "drums": [
+      "Rolling four‑on‑the‑floor kick",
+      "layered trance snare/claps",
+      "syncopated hats"
+    ],
+    "influences": [
+      "1990s melodic vocal trance",
+      "progressive build and drop structure",
+      "Lange’s signature euphoric style"
+    ],
+    "genre": "Trance",
+    "subgenre": "Vocal Uplifting Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=jYsfR7e4gHI"
+    ]
+  },
+  {
+    "id": "crashforce-re-energize",
+    "title": "Re‑Energize",
+    "artist": "Crashforce",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1997",
+      "Germany",
+      "Crashforce"
+    ],
+    "description": "Released in 1997 on the vinyl 12″ *Re‑Energize* via Acid Trance Germany (ATH 012), “Re‑Energize” by Crashforce is a high‑octane acid‑trance track packed with snapping TB‑303 lines, industrial percussion textures, and driving, hypnotic rhythm—about 5:05 in length. It embodies the darker, harder edge of late‑’90s European acid‑trance, with metallic acid hits and relentless groove, making it a favorite among underground DJ sets and trance collectors.",
+    "releaseYear": 1997,
+    "label": "Acid Trance Germany (ATH 012)",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A‑side track of the *Re‑Energize* 12″; widely circulated in acid‑trance vinyl collections and later digital archives.",
+    "synths": [
+      "Roland TB‑303 acid sequences",
+      "metallic percussion stabs"
+    ],
+    "drums": "Hard kicks, acid percussion loops, gated hi‑hats",
+    "influences": [
+      "German underground acid/hard trance",
+      "mid-90s techno‑trance crossover"
+    ],
+    "genre": "Trance",
+    "subgenre": [
+      "Acid",
+      "Hard Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=D0UF5-NyIGU"
+    ]
+  },
+  {
+    "id": "dj-warlock-the-energy",
+    "title": "The Energy",
+    "artist": "DJ Warlock",
+    "tags": [
+      "acid trance",
+      "1997",
+      "Belgium",
+      "Warlock"
+    ],
+    "description": "Released in 1997 on the *Energetik EP* (Buddja BUDD 012) via Belgium’s Buddja label, “The Energy” is an intense acid‑trance cut characterized by deep, rolling TB‑303 basslines, atmospheric pads, and hypnotic four-on‑the‑floor drive across ~8:01 minutes. The track’s tension builds through echoic sweeps and acid stabs, exemplifying late‑90s continental trance — raw yet cinematic. A true underground classic, it became widely shared among DJ sets emphasizing that era’s European acid-trance sound.",
+    "releaseYear": 1997,
+    "label": "Buddja Records (Energetik EP, BUDD 012)",
+    "album": "Energetik EP",
+    "country": "Belgium",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "A‑side lead track on the *Energetik EP* (BUDD 012); alongside *Hallucination* and *Urban Ritual*, it's regularly included in retrospective acid‑trance archives.",
+    "synths": [
+      "Roland TB‑303 acid bass",
+      "ambient trance pads"
+    ],
+    "drums": [
+      "Steady 4/4 kick",
+      "acid percussion loops",
+      "reverb-laced hats"
+    ],
+    "influences": [
+      "Belgian acid‑trance mid‑’90s",
+      "underground trance energy",
+      "deep cosmic textures"
+    ],
+    "genre": "Trance",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=o1VWr7QhrUw"
+    ]
+  },
+  {
+    "id": "cj-bolland-sugar-is-sweeter-armand-mix",
+    "title": "Sugar Is Sweeter (Armand Van Helden’s Drum ’n’ Bass Mix)",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "speed garage",
+      "1996",
+      "Belgium/UK",
+      "Armand Van Helden",
+      "club classic"
+    ],
+    "description": "Armand Van Helden’s remix of C.J. Bolland’s 1996 single “Sugar Is Sweeter” — official A‑side on vinyl and CD releases — became a seminal club anthem. Although titled a “Drum ’n’ Bass Mix,” it aligns more with the speed‑garage aesthetic of the era, featuring swung, skippy beats, dist‑orted bass and chopped-up vocals. The 8:32 version became widely circulated in 1996‑97 club sets and compilations.",
+    "releaseYear": 1996,
+    "label": "Internal/PolyGram / FFRR",
+    "album": null,
+    "country": "Belgium / UK",
+    "artistBorn": "1971-06-18",
+    "artistPrimaryGenre": "Electronic / Techno",
+    "aliases": [
+      "Christian Jay Bolland"
+    ],
+    "chartInfo": "Hit #1 on U.S. Billboard Hot Dance Club Play and reached #11 on UK Singles Chart in 1996 (original version) — the remix drove much of this chart success.",
+    "synths": [
+      "Filtered synth bass",
+      "distorted vocal FX"
+    ],
+    "drums": [
+      "Syncopated speed‑garage drums",
+      "swing‑based skippy hi‑hats",
+      "heavy kick"
+    ],
+    "influences": [
+      "UK speed garage",
+      "mid‑’90s club house",
+      "Van Helden’s remix style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Speed Garage",
+    "youtube": [
+      "https://www.youtube.com/watch?v=d_pJdQGSOCo"
+    ]
+  },
+  {
+    "id": "untidy-djs-funky-groove-rhythm-masters-sub-club-mix",
+    "title": "Funky Groove (Rhythm Masters Sub Club Mix)",
+    "artist": "Untidy DJ’s (Paul Janes)",
+    "tags": [
+      "funky house",
+      "1998",
+      "UK",
+      "Rhythm Masters",
+      "Untidy Trax"
+    ],
+    "description": "A bouncy rework by the Rhythm Masters of Paul Janes’ 'Funky Groove' released originally on Untidy Trax and reissued via Manifesto. This Sub Club Mix leans into funky-house energy with crisp disco‑punch kicks, tight basslines, chopped vocals, and club‑ready groove across ~7:08 minutes.",
+    "releaseYear": 1998,
+    "label": "Manifesto Records / Untidy Trax",
+    "album": "Untidy Dubs Presents Funky Groove",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "Untidy Dubs"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Funky bass stabs",
+      "disco‑style chords"
+    ],
+    "drums": [
+      "Punched four‑on‑the‑floor kick",
+      "syncopated hi‑hats and snares"
+    ],
+    "influences": [
+      "UK funky‑house",
+      "90s disco‑house fusion"
+    ],
+    "genre": "House",
+    "subgenre": "Funky House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=LH14zW-Lhng"
+    ]
+  },
+  {
+    "id": "untidy-djs-funky-groove-rhythm-masters-sub-club-mix",
+    "title": "Funky Groove (Rhythm Masters Sub Club Mix)",
+    "artist": "Untidy DJ’s",
+    "tags": [
+      "funky house",
+      "1998",
+      "UK",
+      "Rhythm Masters",
+      "Untidy Dubs"
+    ],
+    "description": "A club‑oriented rework by Rhythm Masters (Robert Chetcuti & Steve Mac) of Paul Janes’ 'Funky Groove' originally released on Untidy Trax. This Sub Club Mix delivers crisp disco‑funk kicks, tight basslines, chopped vocal tags, and a groovy, funky‑house swing in about ~6:55 minutes.",
+    "releaseYear": 1998,
+    "label": "Manifesto Records / Untidy Trax",
+    "album": "Untidy Dubs Presents Funky Groove",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "Untidy Dubs"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Chopped vocal loops",
+      "funky bass stabs"
+    ],
+    "drums": [
+      "Four‑on‑the‑floor kick",
+      "syncopated hi‑hats and snares"
+    ],
+    "influences": [
+      "UK funky‑house",
+      "90s disco‑house fusion"
+    ],
+    "genre": "House",
+    "subgenre": "Funky House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=LH14zW-Lhng"
+    ]
+  },
+  {
+    "id": "marco-v-indicator-original-mix",
+    "title": "Indicator (Original Mix)",
+    "artist": "Marco V",
+    "tags": [
+      "hard trance",
+      "2001",
+      "UK",
+      "Duty Free Recordings",
+      "clubbing anthem"
+    ],
+    "description": "Marco V’s sizzling hard‑trance single “Indicator” originally released in 2001 on Duty Free Recordings. With its driving 4‑on‑the‑floor kick, soaring synth arpeggios, and crescendo builds, the track became a club mainstay across Europe. Clocking in around 7:09 minutes, it epitomizes early‑2000s European hard‑trance energy.",
+    "releaseYear": 2001,
+    "label": "Duty Free Recordings (DF 031)",
+    "album": null,
+    "country": "UK",
+    "artistBorn": "1967‑04‑26",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "High‑energy trance arps",
+      "anthemic lead synths"
+    ],
+    "drums": [
+      "Driving four‑on‑the‑floor kick",
+      "energetic hi‑hats/snare bounce"
+    ],
+    "influences": [
+      "Early‑2000s hard trance",
+      "Dutch trance club sound"
+    ],
+    "genre": "Trance",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=CFC04jptVOo"
+    ]
+  },
+  {
+    "id": "awesome-3-dont-go",
+    "title": "Don't Go",
+    "artist": "Awesome 3 ft. Julie McDermott",
+    "tags": [
+      "90s house",
+      "1992",
+      "UK",
+      "breakbeat house",
+      "bleep house"
+    ],
+    "description": "“Don’t Go” by Awesome 3 featuring Julie McDermott is a defining track of early ’90s UK rave culture. Originally released in 1992 on Citybeat Records, the song fuses breakbeat-driven house with bleepy synths and soulful vocals. Its anthemic hook and genre‑blending structure made it a mainstay in underground rave sets and later in commercial club circuits. The 1996 reissue on XL Recordings gave the track new life, with remixes that brought it into the mainstream. A seminal blend of rave energy and emotional uplift.",
+    "releaseYear": 1992,
+    "label": "Citybeat Records (original); XL Recordings (1996 reissue)",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "Awesome 3",
+      "The Awesome 3",
+      "Awesome III",
+      "A3"
+    ],
+    "chartInfo": "Reached #27 on the UK Singles Chart and #8 on the UK Dance Singles Chart in 1996 following reissue on XL Recordings.",
+    "synths": [
+      "Bleep-style lead",
+      "sub-bass",
+      "rave stabs"
+    ],
+    "drums": [
+      "Breakbeat groove",
+      "punchy house kick",
+      "syncopated snares"
+    ],
+    "influences": [
+      "UK rave",
+      "bleep house",
+      "Detroit vocal house"
+    ],
+    "genre": "House",
+    "subgenre": [
+      "Bleep House",
+      "Breakbeat House"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=1Dqm-6ghKS4"
+    ]
+  },
+  {
+    "id": "bk-revolution-original-mix",
+    "title": "Revolution (Original Mix)",
+    "artist": "BK",
+    "tags": [
+      "hard house",
+      "hard trance",
+      "2002",
+      "UK",
+      "Nukleuz",
+      "club anthem"
+    ],
+    "description": "One of the most iconic crossover hard‑house tracks, 'Revolution' by BK (Ben Keen) was released in 2002 on Nukleuz. Featuring a soaring synth lead, driving four‑on‑the‑floor rhythm, and euphoric breakdowns, it became a hard‑house anthem that even got daytime airplay on UK Radio 1. It’s considered a genre-defining anthem of the era.",
+    "releaseYear": 2002,
+    "label": "Nukleuz Records",
+    "album": null,
+    "country": "UK",
+    "artistBorn": "1977",
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [
+      "Ben Keen",
+      "BK"
+    ],
+    "chartInfo": "Reached #42 on the UK Singles Chart and #1 on the UK Dance chart in 2002; last vinyl‑only release to chart in UK singles chart.",
+    "synths": [
+      "Pumping lead synth riff",
+      "anthemic arpeggios"
+    ],
+    "drums": [
+      "Driving house kick",
+      "fast hi‑hats clutch pattern"
+    ],
+    "influences": [
+      "UK hard‑house",
+      "early‑2000s rave/trance crossover"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hard House",
+      "Hard Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=SZRsuvWxFzQ"
+    ]
+  },
+  {
+    "id": "todd-edwards-saved-my-life-original-mix",
+    "title": "Saved My Life (Original Mix)",
+    "artist": "Todd Edwards",
+    "tags": [
+      "UK garage",
+      "speed garage",
+      "1995",
+      "Nervous Records",
+      "classic"
+    ],
+    "description": "Todd Edwards' breakthrough single “Saved My Life” (1995) is a landmark in UK garage/speed‑garage, built on his signature chopped-vocal mosaics over swinging four‑on‑the‑floor beats. It became a club staple in the UK underground and later reissued multiple times, notably by Defected Records in 2021.",
+    "releaseYear": 1995,
+    "label": "i! Records / Nervous (multiple reissues incl. 1995 & 2000)",
+    "album": null,
+    "country": "USA / UK",
+    "artistBorn": "1972‑12‑09",
+    "artistPrimaryGenre": "Garage house",
+    "aliases": [
+      "The Messenger",
+      "The Sample Choir",
+      "Sunshine Bros."
+    ],
+    "chartInfo": "Original release became a UK club favourite; remixes and reissues helped cement its influence on early UK garage.",
+    "synths": [
+      "Vocal chopped stabs",
+      "sub‑bass pads"
+    ],
+    "drums": [
+      "Swing‑inflected, shuffling 4/4 kick",
+      "syncopated hats/snare"
+    ],
+    "influences": [
+      "UK garage pioneering",
+      "vocal sample collage technique",
+      "early New York house influences"
+    ],
+    "genre": "House",
+    "subgenre": [
+      "UK Garage",
+      "Speed Garage"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=r8uKbprFjIE"
+    ]
+  },
+  {
+    "id": "freefall-skydive-i-feel-wonderful-original-mix",
+    "title": "Skydive (I Feel Wonderful) (Original Mix)",
+    "artist": "Freefall feat. Jan Johnston",
+    "tags": [
+      "trance",
+      "1998",
+      "UK",
+      "Freefall",
+      "Jan Johnston"
+    ],
+    "description": "Pioneering trance anthem featuring Jan Johnston’s ethereal vocals, written over the instrumental by trance producers Freefall (Alan Bremner & Anthony Pappa). Originally released in 1998, this lush trance cut blends shimmering arps, emotional pad work, and a cascade of vocals. Reissued in 2000 and 2001, it peaked at UK #35 on its third release.",
+    "releaseYear": 1998,
+    "label": "Stress Records (UK)",
+    "album": null,
+    "country": "UK / Australia",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": "UK Singles Chart: originally #75 in 1998, re‑entered at #43 (2000) and peaked at #35 (2001) :contentReference[oaicite:1]{index=1}",
+    "synths": [
+      "Atmospheric arps",
+      "emotive trance pads"
+    ],
+    "drums": [
+      "Steady 4/4 kick",
+      "sparse trance hats"
+    ],
+    "influences": [
+      "Late‑90s UK trance",
+      "vocal-driven emotional trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=S_zJtYD3vgo"
+    ]
+  },
+  {
+    "id": "kerri-chandler-bar-a-thym-extended-mix",
+    "title": "Bar A Thym (Extended Mix)",
+    "artist": "Kerri Chandler",
+    "tags": [
+      "deep house",
+      "2005",
+      "UK",
+      "Beat Music Fund",
+      "club classic"
+    ],
+    "description": "A deep‑house masterclass from Kerri Chandler, originally released on *Bar A Thym / Sunshine & Twilight* (2005). The Extended Mix runs about ~7:24 and showcases Chandler’s signature blend of hypnotic chord stabs, rich piano motifs, deep basslines, and a steadily evolving groove—trusted in his DJ sets and underground club sound systems.",
+    "releaseYear": 2005,
+    "label": "Beat Music Fund (NRK imprint)",
+    "album": null,
+    "country": "UK / US",
+    "artistBorn": "1969‑09‑28",
+    "artistPrimaryGenre": "Deep House",
+    "aliases": [
+      "Kerri Chandler",
+      "Third Generation"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Warm piano chords",
+      "atmospheric deep house pads"
+    ],
+    "drums": [
+      "Soft four‑on‑the‑floor kick",
+      "swing hi‑hats and percussion elements"
+    ],
+    "influences": [
+      "New Jersey deep house tradition",
+      "early King Street / Nite Grooves era"
+    ],
+    "genre": "House",
+    "subgenre": "Deep House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=9UO06d9qsLQ"
+    ]
+  },
+  {
+    "id": "golden-girls-kinetic-99-commies-remix",
+    "title": "Kinetic ’99 (Commie’s Remix)",
+    "artist": "Golden Girls",
+    "tags": [
+      "trance",
+      "1999‑2000",
+      "UK",
+      "Commie",
+      "Kinetic"
+    ],
+    "description": "A driving trance remix of Golden Girls’ original 'Kinetic', updated in 1999/2000 by the producer Commie. The mix delivers layered trance arps, sweeping pads, and a solid club tempo hovering around 6:00–6:02 minutes, often featured in trance DJ sets and compilations of the era.",
+    "releaseYear": 2000,
+    "label": "Vinyl release ‘Kinetic ’99’ series",
+    "album": "Kinetic ’99 The Remixes",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "Arpeggiated trance synths",
+      "wide pad textures"
+    ],
+    "drums": [
+      "Uplifting 4/4 kick",
+      "subtle hi‑hat groove"
+    ],
+    "influences": [
+      "Late‑90s UK trance",
+      "remix culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=oDNBPPjcJPk"
+    ]
+  },
+  {
+    "id": "cortina-music-is-moving-bk-dbm-amber-mix",
+    "title": "Music Is Moving (BK & dBm Amber Mix)",
+    "artist": "Cortina",
+    "tags": [
+      "hard house",
+      "1999‑2000",
+      "UK",
+      "BK & dBm",
+      "Nukleuz"
+    ],
+    "description": "A powerful hard‑house remix of Cortina’s original 'Music Is Moving', reworked in 1999‑2000 by producers BK & dBm Amber. The mix features heavy pumping basslines, energetic synth stabs, and DJ‑ready breakdowns—running about ~7:40 minutes on vinyl. A staple in late‑90s UK club and hard‑house sets.",
+    "releaseYear": 1999,
+    "label": "Nukleuz Records (NUKP 0159)",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [
+      "Cortina (UK hard house)"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Acid‑style stabs",
+      "energetic hard house lead synth"
+    ],
+    "drums": [
+      "Four‑on‑the‑floor beating kick",
+      "fast hi‑hats and percussive claps"
+    ],
+    "influences": [
+      "UK hard house",
+      "late‑90s club energetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=4QcuzpxF-04"
+    ]
+  },
+  {
+    "id": "agent-00-the-magnificent-original-radio-edit",
+    "title": "The Magnificent (Original Radio Edit)",
+    "artist": "Agent 00",
+    "tags": [
+      "speed garage",
+      "1998",
+      "UK",
+      "Inferno Records",
+      "Agent 00",
+      "Age 00"
+    ],
+    "description": "Agent 00’s “The Magnificent” (Original Radio Edit, ~3:51) is a late‑’90s UK speed‑garage jam. Released on Inferno Records in 1998, it features chopped vocals, heavy sub‑bass, and rolling 2‑step rhythms that defined the sound. A shorter radio edit distilled for mainstream and club airplay, while the 12″ mix (~6:43) catered to DJs.",
+    "releaseYear": 1998,
+    "label": "Inferno Records (UK, CD single / 12″)",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "Agent 00",
+      "Age 00"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Sub‑bass wobble",
+      "vocal chopped stabs"
+    ],
+    "drums": [
+      "Shuffled 2‑step kick",
+      "snappy claps and hats"
+    ],
+    "influences": [
+      "UK speed garage",
+      "late‑90s rave / bassline evolution"
+    ],
+    "genre": "House",
+    "subgenre": "Speed Garage",
+    "youtube": [
+      "https://www.youtube.com/watch?v=xDi9L2h_sOE"
+    ]
+  },
+  {
+    "id": "ruff-driverz-waiting-for-the-sun-radio-edit",
+    "title": "Waiting for the Sun (Radio Edit)",
+    "artist": "Ruff Driverz",
+    "tags": [
+      "trance",
+      "1999",
+      "UK",
+      "Ruff Driverz",
+      "Altra Moda Music"
+    ],
+    "description": "The Radio Edit of Ruff Driverz’s trance anthem “Waiting for the Sun,” released in 1999. A concise 3:08 version with a clean structure and vocal hook tailored for radio and single release, distinct from the longer Original Mix (~8:14) and Heliotropic Mix versions.",
+    "releaseYear": 1999,
+    "label": "Altra Moda Music / Inferno",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House / Trance",
+    "aliases": [
+      "2000BC",
+      "Transit"
+    ],
+    "chartInfo": "Peaked at UK #37 and US Dance Club Play chart #2 in 1999‑2000, their biggest hit.",
+    "synths": [
+      "Bright trance arps",
+      "uplifting pads"
+    ],
+    "drums": [
+      "Steady 4‑on‑the‑floor kick",
+      "clean hi‑hat pulses"
+    ],
+    "influences": [
+      "Late‑90s vocal trance",
+      "British house‑trance crossover"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=igjJ9kxGZEU"
+    ]
+  },
+  {
+    "id": "cj-bolland-camargue-original",
+    "title": "Camargue (Original)",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "progressive house",
+      "techno",
+      "1992",
+      "Belgium / UK",
+      "classic rave"
+    ],
+    "description": "A hypnotic, organ-driven techno‑classic from C.J. Bolland released in 1992 on R&S Records, featured on his album *The 4th Sign*. Built around a layered organ riff, pulsing bassline, and imbalanced percussive energy, “Camargue” became a staple of the early‑’90s Belgian and UK rave scene.",
+    "releaseYear": 1992,
+    "label": "R&S Records (RS 92024)",
+    "album": "The 4th Sign",
+    "country": "Belgium / UK",
+    "artistBorn": "1971‑06‑18",
+    "artistPrimaryGenre": "Electronic / Techno",
+    "aliases": [
+      "BCJ",
+      "Space Opera",
+      "Pulse"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Gated organ lead",
+      "acid-influenced bass"
+    ],
+    "drums": [
+      "Minimal techno kicks",
+      "clever gated percussion, hi‑hats"
+    ],
+    "influences": [
+      "Belgian techno",
+      "early ’90s rave",
+      "R&S Records electro‑techno"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Techno",
+      "Progressive House"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=RsrdANlEz8I"
+    ]
+  },
+  {
+    "id": "boccaccio-life-the-secret-wish-club-mix",
+    "title": "The Secret Wish (Original Club Mix)",
+    "artist": "Boccaccio Life",
+    "tags": [
+      "trance",
+      "1997‑1998",
+      "Belgium",
+      "club classic",
+      "Euro trance"
+    ],
+    "description": "The Original Club Mix of “The Secret Wish” by Boccaccio Life is a mid‑late ’90s trance anthem from Belgium. It showcases lush pads, soaring arpeggios, and euphoric breakdowns—running about ~5:13 minutes. Widely featured in European DJ sets and later reissued, it crossed into UK dance charts.",
+    "releaseYear": 1997,
+    "label": "Dance Opera (Belgium)",
+    "album": null,
+    "country": "Belgium",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Adventure Boys",
+      "Allegro",
+      "Body Heat",
+      "Buzzerr",
+      "DJ Don & Svenson",
+      "Leader Of The Nation",
+      "Nightwatchers",
+      "Party Freaks",
+      "Strawberry Flavour"
+    ],
+    "chartInfo": "Reached UK Dance Singles Chart #31 in November 2002 following a reissue on NEO label DMX009.",
+    "synths": [
+      "Arpeggiated trance synths",
+      "wide pad textures"
+    ],
+    "drums": [
+      "Steady 4/4 kick",
+      "light hi‑hat syncopation"
+    ],
+    "influences": [
+      "Late‑90s Belgian trance",
+      "anthemic club trance sound"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Jemqf2UTesE"
+    ]
+  },
+  {
+    "id": "cj-bolland-the-prophet-original-1997",
+    "title": "The Prophet (Original 1997 Mix)",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "techno",
+      "ハード techno",
+      "1997",
+      "UK/Belgium",
+      "classic",
+      "FFRR"
+    ],
+    "description": "A seminal late‑’90s techno/trance hybrid by C.J. Bolland, released as the lead track on the *The Prophet / Sugar Is Sweeter* single in 1997. It features spoken‑word samples (notably Willem Dafoe from *The Last Temptation of Christ*), pulsing riffs, and dark cinematic energy—long celebrated in underground club sets.",
+    "releaseYear": 1997,
+    "label": "FFRR / Internal / London Records",
+    "album": null,
+    "country": "Belgium / UK",
+    "artistBorn": "1971‑06‑18",
+    "artistPrimaryGenre": "Techno / Trance",
+    "aliases": [
+      "BCJ",
+      "Space Opera",
+      "Pulse",
+      "Cee‑Jay"
+    ],
+    "chartInfo": "Reached UK Singles Chart #19 in 1997 as a double A‑side with “Sugar Is Sweeter” ([officialcharts.com](https://www.officialcharts.com/songs/cj-bolland-the-prophet/)).",
+    "synths": [
+      "Minimal pulsing techno synths",
+      "cinematic vocal samples"
+    ],
+    "drums": [
+      "Driving 4/4 kick",
+      "tight claps and hats"
+    ],
+    "influences": [
+      "Belgian techno scene",
+      "cinematic techno-trance crossover",
+      "sample-based motif"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Techno",
+      "Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=ukbRAgXZYtU"
+    ]
+  },
+  {
+    "id": "cj-bolland-counterpoint-original-mix",
+    "title": "Counterpoint (Original Mix)",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "techno",
+      "1995",
+      "Belgium / UK",
+      "The Analogue Theatre",
+      "classic"
+    ],
+    "description": "“Counterpoint” is a penetrating techno cut from C.J. Bolland’s 1996 LP *The Analogue Theatre*, originally released as a single/EP in 1995. Running around ~6:23, the track merges driving mechanical percussion, hypnotic arpeggiated synth lines, and a cold, energetic groove—representative of mid-’90s Belgian techno minimalism.",
+    "releaseYear": 1995,
+    "label": "London Records (part of *The Analogue Theatre* era)",
+    "album": "The Analogue Theatre",
+    "country": "Belgium / UK",
+    "artistBorn": "1971-06-18",
+    "artistPrimaryGenre": "Techno",
+    "aliases": [
+      "BCJ",
+      "Space Opera",
+      "Pulse",
+      "Cee‑Jay"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Arpeggiated techno motifs",
+      "cool staccato leads"
+    ],
+    "drums": [
+      "Syncopated kick and claps",
+      "machine-style hi-hat groove"
+    ],
+    "influences": [
+      "Belgian techno of the mid‑90s",
+      "minimal industrial textures",
+      "Berlin‑style rhythm patterns"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Techno",
+    "youtube": [
+      "https://www.youtube.com/watch?v=K6WeV4UDpo0"
+    ]
+  },
+  {
+    "id": "cj-bolland-people-of-the-universe-original",
+    "title": "People Of The Universe (Original Mix)",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "techno",
+      "1996",
+      "Belgium / UK",
+      "The Analogue Theatre",
+      "progressive"
+    ],
+    "description": "A cosmic techno piece from C.J. Bolland’s 1996 album *The Analogue Theatre*. “People Of The Universe” features hypnotic arpeggios, evolving pads, and a cinematic atmosphere—running about ~6:53. Positioned among standout tracks like “Counterpoint” and “There Can Be Only One,” it helps define Bolland’s mid‑’90s signature sound.",
+    "releaseYear": 1996,
+    "label": "London Records / Internal / PolyGram",
+    "album": "The Analogue Theatre",
+    "country": "Belgium / UK",
+    "artistBorn": "1971‑06‑18",
+    "artistPrimaryGenre": "Techno / Electronic",
+    "aliases": [
+      "BCJ",
+      "Space Opera",
+      "Pulse",
+      "Cee‑Jay"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Hypnotic arpeggiated synths",
+      "spacey pads"
+    ],
+    "drums": [
+      "Steady techno kick",
+      "sparse percussion"
+    ],
+    "influences": [
+      "Belgian techno mid‑’90s",
+      "atmospheric minimalism"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Techno",
+      "Progressive"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=z9QBQ-Ca0NM"
+    ]
+  },
+  {
+    "id": "cj-bolland-desolate-1-original-mix",
+    "title": "Desolate 1 (Original Mix)",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "techno",
+      "1999",
+      "Belgium/UK",
+      "FFRR",
+      "acid techno"
+    ],
+    "description": "A relentless acid‑techno / hard‑techno banger from C.J. Bolland, originally issued in 1999 as the A‑side to the *Desolate 1 / The Tingler* single on FFRR / Essential. Roughly ~7:46, the track is built around pounding acid stabs, mechanical percussion, and a rugged, industrial edge—often featured in underground techno DJ sets.",
+    "releaseYear": 1999,
+    "label": "FFRR / Essential Recordings (EXXDJ 5, promo 12″)",
+    "album": null,
+    "country": "UK / Belgium",
+    "artistBorn": "1971‑06‑18",
+    "artistPrimaryGenre": "Techno",
+    "aliases": [
+      "BCJ",
+      "Space Opera",
+      "Pulse",
+      "Cee‑Jay"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "Acid‑style TB‑303 stabs",
+      "industrial synth FX"
+    ],
+    "drums": [
+      "Machine‑driven 4/4 kick",
+      "metallic percussion loops"
+    ],
+    "influences": [
+      "Late‑90s hard techno",
+      "Belgian acid techno",
+      "industrial club sound"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Techno",
+      "Acid Techno"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=ylQHzQII61w"
+    ]
+  },
+  {
+    "id": "cj-bolland-it-aint-gonna-be-me",
+    "title": "It Ain't Gonna Be Me",
+    "artist": "C.J. Bolland",
+    "tags": [
+      "techno",
+      "1999",
+      "UK / Belgium",
+      "Essential Recordings",
+      "acid techno"
+    ],
+    "description": "An energetic acid techno track by C.J. Bolland released in 1999 on Essential Recordings. Known for its pulsating TB-303 bassline and driving percussion, this track exemplifies late 90s European techno underground.",
+    "releaseYear": 1999,
+    "label": "Essential Recordings",
+    "album": null,
+    "country": "UK / Belgium",
+    "artistBorn": "1971-06-18",
+    "artistPrimaryGenre": "Techno",
+    "aliases": [
+      "Cee-Jay",
+      "BCJ"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": 35
     },
-    {
-  "id": "astrobug-cop-show",
-  "title": "Cop Show",
-  "artist": "Astrobug",
-  "tags": ["acid trance", "psy‑trance", "1998", "UK", "Paradigm Shift"],
-  "description": "Released in 1998 as the A‑side of a Paradigm Shift Recordings 12″ (*Cop Show / Pandora’s Box*), ‘Cop Show’ is an underground acid/psy‑trance cut featuring dry, looping TB‑303 lines, rugged percussion, and a hypnotic groove around 7:30 in length—often played in late‑90s UK sets.",
-  "releaseYear": 1998,
-  "label": "Paradigm Shift Recordings (Para 003)",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Cop Show / Pandora’s Box"],
-  "chartInfo": "Cult underground classic among acid‑trance and psy‑trance vinyl circles :contentReference[oaicite:1]{index=1}",
-  "synths": ["Roland TB‑303", "analog acid percussion"],
-  "drums": "Layered acid percussion, driving dry kicks, hi‑hat rolls",
-  "influences": ["UK acid trance", "psy‑trance crossover in the late 1990s"],
-  "genre": "Trance",
-  "subgenre": "Acid / Psy‑Trance",
-  "youtube": ["https://www.youtube.com/watch?v=UasAK9oEmFo"]
-   },
-   {
-  "id": "caterpillar-give-me-your-hand",
-  "title": "Give Me Your Hand",
-  "artist": "Caterpillar",
-  "tags": ["acid trance", "1995", "Germany", "Phuture Wax"],
-  "description": "Released in 1995 on the *How Do You Feel* 12″ (Phuture Wax WAX 006‑6), this track ‘Give Me Your Hand’ is a dark acid‑trance cut featuring squelchy TB‑303 acid lines, metallic percussion loops, and a tight 4/4 groove—it became a fixture in mid‑90s European underground DJ sets.",
-  "releaseYear": 1995,
-  "label": "Phuture Wax (WAX 006‑6)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Included on the *How Do You Feel* 12″ alongside ‘How Do You Feel’ and ‘Lost In 303’, frequently featured in European compilations like United DJs Of America Vol. 5 ([discogs.com](https://www.discogs.com/release/1105549-Caterpillar-How-Do-You-Feel) and master listing) :contentReference[oaicite:1]{index=1}.",
-  "synths": ["Roland TB‑303"],
-  "drums": "Acid percussion loops, sharp kicks, subtle claps",
-  "influences": ["German acid‑trance scene", "mid‑90s rave culture"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=-XYtZioisXA"]
-   },
-   {
-  "id": "defcon69-city-x-hard-mix",
-  "title": "City X (Hard Mix)",
-  "artist": "Defcon 69",
-  "tags": ["acid trance", "1996", "Belgium", "Hard Mix"],
-  "description": "Released in 1996 on the *City X* 12″ (Acid Trance style), the Hard Mix is a raw 4:45 acid‑trance cut featuring sharp TB‑303 lines, driving percussion loops, and a hypnotic groove typical of mid‑90s Belgian acid trance.",
-  "releaseYear": 1996,
-  "label": "Acid Trance / Unknown Belgian label",
-  "album": null,
-  "country": "Belgium",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["City X (Dream Mix)", "City X (Woo Mix)"],
-  "chartInfo": "The A‑side Hard Mix runs 4:45 and is often cited as a standout acid‑trance variant on the City X release ([discogs.com](https://www.discogs.com/release/590316-Defcon-69-City-X) entry) :contentReference[oaicite:1]{index=1}.",
-  "synths": ["Roland TB‑303"],
-  "drums": "Acid percussion loops, punchy kicks, repetitive gated hats",
-  "influences": ["1990s Belgian acid‑trance scene", "harder acid remix aesthetics"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": []
+    "synths": [
+      "TB-303 acid bassline",
+      "analog synth leads"
+    ],
+    "drums": [
+      "4/4 kick drum",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "Belgian techno",
+      "acid house",
+      "late 90s underground techno"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Techno",
+      "Acid Techno"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=QxIjXleuL5k"
+    ]
   },
   {
-  "id": "joshua-ryan-pistolwhip",
-  "title": "Pistolwhip",
-  "artist": "Joshua Ryan",
-  "tags": ["trance", "uplifting trance", "2000", "USA", "classic trance"],
-  "description": "Originally released in 2000 (sometimes noted as 1999) on NuLife Records, ‘Pistolwhip’ is an uplifting trance anthem featuring driving basslines, rolling percussion, sweeping synth pads, and high‑energy arpeggios—it spawned several remixes and became a fixture in early‑2000s trance sets.",
-  "releaseYear": 2000,
-  "label": "NuLife (USA)",
-  "album": null,
-  "country": "USA",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Way Out West Remix", "James Holden Remix", "Ariel Remix"],
-  "chartInfo": "Originally issued on vinyl and CD, it featured remixes by Way Out West, James Holden, and Ariel—widely featured in trance compilations and DJ sets :contentReference[oaicite:1]{index=1}.",
-  "synths": ["Roland JP‑8000", "Access Virus", "digital trance synths"],
-  "drums": "Driving kick‑heavy 4/4, rolling hi‑hats, gated snare fills",
-  "influences": ["classic Uplifting/epic trance style of late‑90s/early‑2000s"],
-  "genre": "Trance",
-  "subgenre": "Uplifting Trance",
-  "youtube": []
-   },
-   {
-  "id": "atlantis-vs-avatar-fiji",
-  "title": "Fiji",
-  "artist": "Atlantis vs. Avatar (featuring Miriam Stockley)",
-  "tags": ["classic trance", "vocal trance", "ambient trance", "1999", "UK", "USA"],
-  "description": "Released in 1999 by Atlantis vs. Avatar, ‘Fiji’ is a lush, emotional trance anthem featuring the ethereal vocals of Miriam Stockley, known for her work with Adiemus. The track blends sweeping ambient pads, arpeggiated synths, and a rolling four-on-the-floor trance beat to create a cinematic, almost spiritual soundscape. Originally issued by Inferno and Subterania, it quickly became a favorite in progressive and vocal trance circles. ‘Fiji’ gained further exposure through Tiësto’s *Magik Five: Heaven Beyond* compilation and was widely remixed by artists like Lange and Binary Finary, helping it become a definitive track of the late 1990s trance era.",
-  "releaseYear": 1999,
-  "label": "Subterania / Inferno Records",
-  "album": null,
-  "country": "UK / USA",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Atlantis – Fiji", "Atlantis vs Avatar – Fiji"],
-  "chartInfo": "Featured on *Magik Five* by Tiësto and received extensive airplay on trance compilations. Charted modestly in the UK Singles Chart upon re-release with the Lange Remix in 2001.",
-  "synths": ["Access Virus", "JP‑8000", "Korg Trinity", "ambient vocal pads"],
-  "drums": "Classic uplifting trance kicks, subtle snare fills, ambient percussion layers",
-  "influences": ["Adiemus vocal style", "late‑90s UK progressive and vocal trance scene"],
-  "genre": "Trance",
-  "subgenre": "Vocal / Ambient Trance",
-  "youtube": ["https://www.youtube.com/watch?v=9ydVtYAftbM"]
-   },
-   {
-  "id": "audience-flow-the-mind-is-different-club-attack",
-  "title": "The Mind Is Different (Club Attack)",
-  "artist": "Audience Flow",
-  "tags": ["acid hard trance", "1999", "Germany", "Club Attack Mix"],
-  "description": "Released in 1999 on the *The Mind Is Different / Take Me Away* vinyl single (Soundtraxx Music Production SMP2‑18), the Club Attack Mix delivers tight acid-trance energy. At around 6:04 in length, it’s driven by aggressive rolling TB‑303 patterns, hard-hitting trance kicks, and trance‑style stabs. Frequently featured in underground DJ sets in German club circuits of the late ’90s.",
-  "releaseYear": 1999,
-  "label": "Soundtraxx Music Production (SMP2‑18)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["The Mind Is Different / Take Me Away 12″"],
-  "chartInfo": "A‑side Club Attack Mix of vinyl single; also issued in Extended Mix (~6:31) and paired with 'Take Me Away (Club Mix)' on the B‑side ([discogs.com release entry])",
-  "synths": ["Roland TB‑303", "Access Virus-style synth pads"],
-  "drums": "Punchy 4/4 kicks, gated hi‑hats, rolling trance percussion",
-  "influences": ["German acid/hard trance of late‑1990s", "club‑focused trance production"],
-  "genre": "Trance",
-  "subgenre": "Acid Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=8cNNlIH0sTA"]
-   },
-   {
-  "id": "cyberotic-night-in-istanbul",
-  "title": "Night in Istanbul",
-  "artist": "Cyberotic",
-  "tags": ["acid trance", "1994", "Germany", "Cyberotic"],
-  "description": "Originally released in 1994 on the *Passions EP* by Cyberotic, “Night in Istanbul” is a signature acid‑trance instrumental featuring squelchy TB‑303 lines, metallic acid percussion, and a hypnotic rolling groove at roughly 5:46. It reflects the raw energy of mid‑90s German acid trance and became a cult favorite in underground sets.",
-  "releaseYear": 1994,
-  "label": "Cyberotic (Passions EP, 1994)",
-  "album": "Passions EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A‑side of the *Passions EP* (track A1) alongside ‘Rising Sun’ and ‘130 BPM Drive’—widely circulated in mid‑90s acid sets and clubnight compilations ([discogs.com](https://www.discogs.com/release/210756-Cyberotic-Passions-EP) ).",
-  "synths": ["Roland TB‑303", "classic 1990s acid percussion synthesis"],
-  "drums": "Dry acid percussion loops, tight kicks, minimal hi‑hat rolls",
-  "influences": ["German 90s acid trance scene", "early rave minimalism"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ppE72mLe6SU"]
-   },
-   {
-  "id": "dj-mishka-fifth-element-skyscraper-mix",
-  "title": "Fifth Element (Skyscraper Mix)",
-  "artist": "DJ Mishka",
-  "tags": ["acid trance", "1998", "UK", "Skyscraper Mix"],
-  "description": "Originally released in 1998 by DJ Mishka on Voltage Controlled Frequencies (VCF‑011, UK white label), the Skyscraper Mix of 'Fifth Element' delivers a searing acid‑trance experience. Clocking in at around 7:25, it layers TB‑303 acid lines over hypnotic percussion, sweeping pads, and trance‑style arpeggios, typical of late‑90s UK underground sound.",
-  "releaseYear": 1998,
-  "label": "Voltage Controlled Frequencies (VCF‑011)",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Fifth Element (Original Mix)", "Fifth Element (Skyscraper Mix)"],
-  "chartInfo": "Issued on a UK white‑label 12″ along with the Original Mix; became a cult acid‑trance cut in underground DJ sets.",
-  "synths": ["Roland TB‑303", "Access Virus‑style trance synths"],
-  "drums": "Driving kicks, acid percussion loops, tight hi‑hat rolls",
-  "influences": ["UK acid‑trance and rave aesthetic of the late ’90s"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=oXAPv_wkSX4"]
-   },
-   {
-  "id": "ppk-reload-radio-edit",
-  "title": "Reload (Radio Edit)",
-  "artist": "PPK",
-  "tags": ["trance", "radio edit", "2002", "Russian trance", "hit single"],
-  "description": "Released in 2002, ‘Reload (Radio Edit)’ is the single version of PPK’s reinterpretation of 'Zodiak' by Latvian band Zodiaks. Clocking in at approximately 3:29, this concise edit became a minor UK chart hit (peaking at #39), epitomizing accessible Russian trance with memorable melodies and polished production. The group PPK—named after its original members Sergey Pimenov, Alexander Polyakov, and Roman Korzhov—rose to international prominence following their earlier single ‘ResuRection’.",
-  "releaseYear": 2002,
-  "label": "Perfecto / PPK Management (iRecords)",
-  "album": "Russian Trance: Formation",
-  "country": "Russia",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Sergey Pimenov", "Alexander Polyakov", "Roman Korzhov"],
-  "chartInfo": "Peaked at #39 on the UK Singles Chart following the international success of “ResuRection” ([en.wikipedia.org](https://en.wikipedia.org/wiki/PPK_%28duo%29))",
-  "synths": ["Digital trance synths inspired by 'Zodiak' theme"],
-  "drums": "Clean four-on‑the‑floor kicks, subtle hi‑hats, vocal‑style patterns",
-  "influences": ["Latvian electronic melody 'Zodiak', Russian trance style", "late‑90s/early‑00s trance"],
-  "genre": "Trance",
-  "subgenre": "Melodic Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ZsrB457pfFo"]
-   },
-   {
-  "id": "wawa-thomas-gold-latin-thing-dub-mix",
-  "title": "Latin Thing (Thomas Gold Dub Mix)",
-  "artist": "Wawa & Thomas Gold",
-  "tags": ["house", "electro house", "2007", "Haiti Groove", "Thomas Gold remix"],
-  "description": "Released in September 2007 on Haiti Groove Recordings, ‘Latin Thing (Thomas Gold Dub Mix)’ is a high‑energy electro house rework produced by Thomas Gold in collaboration with Wawa. Running around 7:18–7:31, it layers Latin‑flavored rhythms, punchy house beats, and grooving synth lines, typical of mid‑2000s electro house styles.",
-  "releaseYear": 2007,
-  "label": "Haiti Groove Recordings (HGR‑018)",
-  "album": null,
-  "country": "Germany / International",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["Thomas Gold (Beat Riders, Dee‑Luxe, Frank Knebel, Frankk, Level K, Plastic)", "Wawa"],
-  "chartInfo": "Popular in the European house club scene; featured in DJ sets and Beatport electro house charts.",
-  "synths": ["Digital house synths", "Latin percussive samples"],
-  "drums": "Punchy four‑on‑the‑floor kicks, layered percussion, offbeat hi‑hats",
-  "influences": ["Latin house style", "mid‑2000s electro house trends"],
-  "genre": "House",
-  "subgenre": "Electro House",
-  "youtube": ["https://www.youtube.com/watch?v=YlheFu8LH9A"]
-   },
-   {
-  "id": "latin-thing-latin-intruder-mix",
-  "title": "Latin Thing (Latin Intruder Mix)",
-  "artist": "Latin Thing",
-  "tags": ["house", "Latin house", "1995", "electro house", "Latin Intruder Mix"],
-  "description": "Released in 1995 on Faze 2 as part of a 12″ promo, ‘Latin Thing (Latin Intruder Mix)’ is a percussion-heavy Latin house track that blends tribal rhythms with punchy house grooves and vocal loops. This version stands out with its more stripped-down club format, running approximately 5:00. It was circulated among DJs in white-label form and gained underground popularity during the mid-’90s club scene.",
-  "releaseYear": 1995,
-  "label": "Faze 2 (Promo 12″)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["The Latin Intruders", "Latin Thing"],
-  "chartInfo": "Released as a 12″ white label promo including the Alive Mix and Eat Me Edit; gained popularity in Latin and tribal house DJ sets.",
-  "synths": ["Digital tribal synths", "Latin percussion stabs"],
-  "drums": "Four-on-the-floor kicks, tribal percussion loops, minimal hats",
-  "influences": ["Latin house fusion", "tribal house", "1990s club cuts"],
-  "genre": "House",
-  "subgenre": "Latin House",
-  "youtube": ["https://www.youtube.com/watch?v=wIN9XCXNlkU"]
-   },
-   {
-  "id": "king-booo-tunes-since-89",
-  "title": "Tunes Since '89",
-  "artist": "KING BOOO!",
-  "tags": ["UK garage", "rave revival", "2024", "London", "4×4 garage"],
-  "description": "Released in June 2024 on Attention Deficit Recordings, 'Tunes Since '89' is a UK‑garage track steeped in nostalgia—employing emotive vocal chops, glittery piano stabs, warm pads, and a punchy 4×4 garage groove. The track pays homage to classic late‑’80s/early‑’90s UK rave culture while remaining contemporary in production, widely featured across independent UKG blogs and DJ sets.",
-  "releaseYear": 2024,
-  "label": "Attention Deficit Recordings",
-  "album": "Tunes Since '89 (Single)",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Garage",
-  "aliases": ["KING BOOO!"],
-  "chartInfo": "Released via Bandcamp and SoundCloud in mid-2024; featured heavily in modern UKG DJ circuits and editorial coverage.",
-  "synths": ["Digital UKG piano stabs", "warm ambient pads"],
-  "drums": "Punchy 4‑on‑the‑floor garage beats with shuffled hi‑hats",
-  "influences": ["late‑’80s UK rave piano house", "early 4×4 garage", "modern melodic garage"],
-  "genre": "Garage",
-  "subgenre": "UK Garage",
-  "youtube": ["https://www.youtube.com/watch?v=m47I7JiNU1k"]
-   },
-   {
-  "id": "radiotrance-vostok",
-  "title": "Vostok (Vostok 5)",
-  "artist": "Radiotrance (DJ Cosmonaut & DJ Zajats)",
-  "tags": ["goa trance", "1997", "Russia", "classic trance"],
-  "description": "A standout Goa‑trance journey released in 1997 on *The Russian EP* (Transient Records), ‘Vostok’—often labeled ‘Vostok 5’—features hypnotic melodic sequencing, cosmic arpeggios, and sweeping synth work over roughly 8 minutes. A seminal Russian Goa track and key emergence for Eastern Bloc trance sound.",
-  "releaseYear": 1997,
-  "label": "Transient Records (TRA032)",
-  "album": "The Russian EP",
-  "country": "Russia / UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Vostok 5"],
-  "chartInfo": "Track A2 on *The Russian EP*; gained cult status among Goa communities and was featured in early UK Goa compilations.",
-  "synths": ["Classic Goa arps", "digital trance pads", "acid bass sequences"],
-  "drums": "Driving kick, layered percussion, off‑beat hats with rhythmic pulses",
-  "influences": ["1990s Goa trance pioneers", "Eastern European trance sound"],
-  "genre": "Trance",
-  "subgenre": "Goa Trance",
-  "youtube": ["https://www.youtube.com/watch?v=oF8nDt7rFRI"]
-   },
-   {
-  "id": "nostrum-trance-on-ecstasy",
-  "title": "Trance On Ecstasy",
-  "artist": "Nostrum",
-  "tags": ["acid trance", "hard trance", "1994", "Germany", "Time Unlimited"],
-  "description": "Released in 1994 on Time Unlimited, ‘Trance On Ecstasy’ is one of Nostrum’s earliest and most iconic acid trance anthems. With cascading TB‑303 acid lines, euphoric leads, and hard, rolling percussion, the track captures the peak energy of the early European trance movement. It became a staple in mid-’90s German underground rave culture and helped define Nostrum’s signature melodic-acid sound.",
-  "releaseYear": 1994,
-  "label": "Time Unlimited (TIME 004)",
-  "album": "Trance On Ecstasy (12\")",
-  "country": "Germany",
-  "artistBorn": "Bernd Augustinski",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "DJ Nostrum"],
-  "chartInfo": "Featured on numerous German trance compilations in the mid-'90s; revered as a foundational acid trance release from Time Unlimited.",
-  "synths": ["Roland TB‑303", "JP‑8000", "Access Virus"],
-  "drums": "Relentless kick drum, acid percussion loops, gated snares, hi-hat flutters",
-  "influences": ["early German acid trance", "European rave scene", "Goa-adjacent melodic trance"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance / Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=bSzdHKynQks"]
-   },
-   {
-  "id": "dj-choci-strange-when-youre-twisted-3ofi-mix",
-  "title": "Strange When You’re Twisted (3OFI Mix)",
-  "artist": "DJ Choci",
-  "tags": ["acid trance", "hard trance", "1998", "UK", "3OFI Mix"],
-  "description": "Released in 1998 on Cannon Records (catalog CANNON6), the *3OFI Mix* of “Strange When You’re Twisted” is an aggressive acid‑spin on trance and hard house. Wrapped around rugged 303 acid stabs, rolling kicks and hypnotic trance motifs, this version stands out in DJ Choci’s discography and in late‑90s UK underground sets.",
-  "releaseYear": 1998,
-  "label": "Cannon Records (CANNON6)",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A‑side 12″ mix commonly circulated in UK club and acid‑trance circles; paired with the Jon Doe Remix on the release :contentReference[oaicite:1]{index=1}",
-  "synths": ["Roland TB‑303 acid lines", "digital trance synth stabs"],
-  "drums": "Driving hard 4/4 kicks, acid percussion loops, crisp hi‑hats",
-  "influences": ["UK acid‑house/trance crossover", "late‑90s acid‑trance style"],
-  "genre": "Trance",
-  "subgenre": "Acid / Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=TJejR1Lwylo"]
-   },
-   {
-  "id": "legacy-the-rain",
-  "title": "The Rain",
-  "artist": "Legacy",
-  "tags": ["trance", "1997", "Germany", "Legacy"],
-  "description": "Released in 1997 on Reef Recordings (catalog REEF001‑6), ‘The Rain’ by German trance act Legacy is a mid‑tempo classic blending dreamy pads, vocals, and melodic trance motifs. Clocking around 6–7 minutes, the track exemplifies late‑’90s chilled trance and remains a cult favorite in European trance archives.",
-  "releaseYear": 1997,
-  "label": "Reef Recordings (REEF001‑6)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A standalone single; distributed in Germany and Eastern Europe, frequently featured in vintage trance DJ sets.",
-  "synths": ["Warm ambient pads", "vocal synth textures"],
-  "drums": "Gentle kick‑based 4/4 beat with soft hi‑hats and emotional percussion",
-  "influences": ["German melodic trance", "late‑90s chill‑trance aesthetics"],
-  "genre": "Trance",
-  "subgenre": "Melodic / Chill Trance",
-  "youtube": ["https://www.youtube.com/watch?v=D7fLbnpK9i0"]
-   },
-   {
-  "id": "tb-tuner-in-303-we-trust",
-  "title": "In 303 We Trust",
-  "artist": "TB‑Tuner",
-  "tags": ["acid trance", "1997", "Germany", "TB‑Tuner"],
-  "description": "Released in 1997 on the 12″ *After Works* (Acid Trance Germany), ‘In 303 We Trust’ is a definitive acid‑trance bomb featuring squelchy TB‑303 basslines, stripped-down percussion loops, and a hypnotic groove of around 4:43. A cult favorite in late‑90s underground acid‑trance sets, the track has seen steady circulations in DJ mixes and archival playlists.",
-  "releaseYear": 1997,
-  "label": "Acid Trance Germany (After Works 12″)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "Appears as track B2 on the *After Works* vinyl; widely referenced in trance archives and acid‑trance collections.",
-  "synths": ["Roland TB‑303 acid bass", "analog acid percussion"],
-  "drums": "Minimal kicks, acid percussion loops, simple hi‑hat pulse",
-  "influences": ["German acid‑trance style of the mid‑1990s", "TB‑303-driven grooves"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=X7apHGkXnIw"]
-   },
-   {
-  "id": "rezoid-again",
-  "title": "Again",
-  "artist": "RezoïD",
-  "tags": ["acid trance", "1994", "Belgium", "RezoïD"],
-  "description": "Released in 1994 on the *Total Attack* 12″ (Dance Opera DO 383), ‘Again’ is a blistering acid‑trance cut featuring squelchy TB‑303 basslines, resonant acid percussion, and a hypnotic driving groove around 5:33. It captures the raw energy of mid‑’90s Belgian trance and remains a cult track in underground DJ circles.",
-  "releaseYear": 1994,
-  "label": "Dance Opera (DO 383)",
-  "album": "Total Attack 12″",
-  "country": "Belgium",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Eric Beysens", "Kris Luyckx", "D.A. Project", "Dream Frequence", "Pressure Generator 1"],
-  "chartInfo": "B‑side of *Total Attack* release (A‑side “Total Attack (On Trance)”); frequently featured in archival acid‑trance sets.",
-  "synths": ["Roland TB‑303", "analog acid percussion synthesis"],
-  "drums": "Driving kick‑heavy 4/4 beat, acid percussion loops, minimal hats",
-  "influences": ["Belgian acid‑trance style", "mid‑’90s rave sound"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=jECY_c6dGq0"]
-   },
-   {
-  "id": "creambase1-fiddle2003-bellinibrothers-radio-cut",
-  "title": "Fiddle 2003 (Bellini Brothers Radio Cut)",
-  "artist": "Creambase 1",
-  "tags": ["electro house", "2003", "Germany", "Bellini Brothers remix", "Radio Cut"],
-  "description": "Released in September 2003 on Gang Go Music/Kontor (catalog PRO4140/GG072), ‘Fiddle 2003 (Bellini Brothers Radio Cut)’ is a high‑energy electro house remix running about 3:30. It blends chopped fiddle samples, pounding house beats, and Brazilian‑flavored percussion—typical of mid‑2000s club radio edits.",
-  "releaseYear": 2003,
-  "label": "Gang Go Music / Kontor Records (PRO4140 / GG072)",
-  "album": "Fiddle 2003 (Single / CD Maxi)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": [],
-  "chartInfo": "Featured on *Club Rotation Volume 23* and *Dream Dance 29* compilations; runtime ~3:30 as Radio Cut version ([discogs.com](https://www.discogs.com/master/182434-Creambase-1-Fiddle-2003) ) ",
-  "synths": ["Synth fiddle samples", "digital electro-house synths"],
-  "drums": "Four‑on‑the‑floor kicks, offbeat percussion loops, percussive stabs",
-  "influences": ["Latin‑flavored house", "mid‑2000s club edits"],
-  "genre": "House",
-  "subgenre": "Electro House",
-  "youtube": []
-   },
-   {
-  "id": "tiesto-traffic",
-  "title": "Traffic",
-  "artist": "Tiësto",
-  "tags": ["trance", "instrumental", "2003", "Dutch trance"],
-  "description": "Released as a single in October 2003 and later featured on his 2004 album *Just Be*, “Traffic” is a seminal instrumental trance track built around hypnotic rhythmic percussion, minimal melodic stabs, and a driving tempo—widely regarded as Tiësto’s first track to reach #1 on the Dutch charts, and one of the first instrumental trance singles to top a national singles ranking.",
-  "releaseYear": 2003,
-  "label": "Magik Muzik / Black Hole Recordings",
-  "album": "Just Be",
-  "country": "Netherlands",
-  "artistBorn": "Tijs Michiel Verwest (Tiësto)",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Stray Dog", "Steve Forte Rio", "Allure", "VER:WEST", "TST", "Glycerine"],
-  "chartInfo": "Originally released Oct 8, 2003, peaked #1 in Netherlands — first instrumental trance single to do so in over two decades. B‑side to 'Love Comes Again' single and featured in *Parade of the Athletes* compilation ([turn0search18] [turn0search20] [turn0search2])",
-  "synths": ["Digital trance synth stabs", "rhythmic percussive loops"],
-  "drums": "Driving four‑on‑the‑floor kick, layered tribal percussion, sparse hats",
-  "influences": ["Minimal techno rhythms", "early 2000s trance", "sample-based electronic structure"],
-  "genre": "Trance",
-  "subgenre": "Instrumental Trance",
-  "youtube": ["https://www.youtube.com/watch?v=cSW3y98ObQY"]
-   },
-   {
-  "id": "dj-zinc-138-trek",
-  "title": "138 Trek",
-  "artist": "DJ Zinc",
-  "tags": ["UK garage", "breakstep", "2000", "UK", "classic"],
-  "description": "Released in November 2000 (recorded in 1999), “138 Trek” is a pioneering UK garage/breakstep single from British producer DJ Zinc. Built around a stuttering loop from Barry White’s “I’m Gonna Love You Just a Little More Baby”, plus sound bites from *Star Trek*, the track clocks ~5:10 and became a UK No. 27 hit—making it one of the first instrumental garage singles to chart in the mainstream. Its raw, stripped-back rhythm and quirky samples made it a game‑changing fusion of drum & bass, garage, and bass‑step.",
-  "releaseYear": 2000,
-  "label": "True Playaz / Phaze:One",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": "Benjamin Pettit",
-  "artistPrimaryGenre": "UK Garage / Bassline",
-  "aliases": ["Jammin", "Jack Ruby", "Dope Skillz", "The Phantom"],
-  "chartInfo": "Released 6 November 2000; peaked at UK Singles Chart #27 and UK Dance Chart #1—one of the first non-vocal garage tracks to break top‑40 in the UK :contentReference[oaicite:0]{index=0}.",
-  "synths": ["Breakbeat loop (Barry White)", "minimal garage synth stabs"],
-  "drums": ["Half‑time 4/4 kick", "syncopated breakstep pattern", "vocal chops and sampled effects"],
-  "influences": ["Jungle/drum & bass to garage crossover", "UK garage innovation around 140 BPM"],
-  "genre": "Garage",
-  "subgenre": "UK Garage / Breakstep",
-  "youtube": ["https://www.youtube.com/watch?v=MfmqmrFHJZg"]
-   },
-   {
-  "id": "drax-amphetamine-original-remaster",
-  "title": "Amphetamine (Original Remaster)",
-  "artist": "Thomas P. Heckmann (Drax Ltd. II)",
-  "tags": ["techno", "acid techno", "peak time techno", "2012 remaster", "German techno"],
-  "description": "Originally produced in 1994 under the alias Drax Ltd. II, “Amphetamine” became a hallmark of early acid‑techno. This 2012 **Original Remaster** brings enhanced clarity and punch to the original: ruthless TB‑303 acid basslines, industrial EBM‑styled pads, and tight, driving drums in an extended ~6:44 version. The remix preserved the ruthlessly minimal structure while boosting the sound’s intensity and modern relevance. It’s widely regarded as a cornerstone track in the acid‑techno revival of the 2010s, still featured in peak‑time techno sets and retrospective compilations.",
-  "releaseYear": 2012,
-  "label": "AFU Limited / Trope Recordings (AFUltd.31)",
-  "album": "Drax Trilogy Special Final Edition",
-  "country": "Germany",
-  "artistBorn": "Thomas Peter Heckmann",
-  "artistPrimaryGenre": "Techno",
-  "aliases": ["Drax Ltd. II", "Exit 100", "Age", "Silent Breed", "Knarz", "Welt In Scherben"],
-  "chartInfo": "Remastered for digital re-release in 2012; frequently paired with the Umek Remix and included in Trope’s *The Complete Remixes and Versions 1994–2012* compilation.",
-  "synths": ["Roland TB‑303", "hard analog acid synth textures", "industrial pad layers"],
-  "drums": ["Punchy techno kick", "acid percussion loops", "layered snare fills and sequenced pulses"],
-  "influences": ["German industrial and EBM", "mid‑90s acid techno movement", "Drax Trilogy ethos"],
-  "genre": "Techno",
-  "subgenre": "Acid / Peak Time Techno",
-  "youtube": ["https://www.youtube.com/watch?v=aps-fDmkE1c"]
-   },
-   {
-  "id": "neuromancer-pennywise",
-  "title": "Pennywise",
-  "artist": "Neuromancer",
-  "tags": ["breakbeat hardcore", "early‑90s", "1992", "UK rave", "classic"],
-  "description": "Originally released in 1992 on Symphony Sound Records (catalog SYM 003), “Pennywise” by Neuromancer is a fierce breakbeat hardcore anthem. Clocking in at around 5:20, the track layers rolling breakbeats over chopped vocal samples, eerie pads, and iconic movie dialogue (_“They all float down here…”_), blending UK rave aggression with raw sampling energy. You’ll hear mickey finn & bay b kane remix variations later in the ’90s, but the original mix stands as a cornerstone in the early hardcore + breakbeat continuum.",
-  "releaseYear": 1992,
-  "label": "Symphony Sound Records (SYM 003)",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat Hardcore",
-  "aliases": ["Neuromancer (UK)", "Penny‑Wise Remixers"],
-  "chartInfo": "Originally issued as a UK 12″ single; widely bootlegged and re‑released across hardcore citations and retrospective mixes.",
-  "synths": ["Rave pads", "sample-triggered movie dialogue"],
-  "drums": ["Hard breakbeats (Amen loops style)", "stuttering vocal chops", "timed reverbed claps"],
-  "influences": ["1990–'92 UK Madchester/Hardcore rave aesthetic", "heavy sampling culture", "early jungle/drum‑&‑bass crossover"],
-  "genre": "Breakbeat Hardcore",
-  "subgenre": "Rave / Early Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=vQFbrzFpDzo"]
-   },
-   {
-  "id": "liquid-liquid-journey-into-dub",
-  "title": "Liquid Is Liquid (Journey Into Dub)",
-  "artist": "Liquid (Ame & Model)",
-  "tags": ["hardcore", "breakbeat", "1994", "UK", "Red Jerry Dub"],
-  "description": "Originally released in 1994 on XL Recordings as part of the *Liquid Love* / *Liquid Is Liquid* EPs, “Liquid Is Liquid (Red Jerry’s Epic Journey Into Dub)” is a standout interpretation by Red Jerry. Clocking ≈11:25, this version unfolds into a cosmic breakdown with echo-laden pads, rolling breakbeats, and hypnotic dub atmospherics built over the original hardcore foundation. A staple in 1990s UK rave culture, it bridges hardcore, ambient, and early drum‑&‑bass sensibilities, and has retained lasting prestige in the archival DJ circuit.",
-  "releaseYear": 1994,
-  "label": "XL Recordings (XLT 48 / Liquid Love EP)",
-  "album": "Liquid Love EP",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat Hardcore",
-  "aliases": ["Liquid", "Ame & Model"],
-  "chartInfo": "Part of *Liquid Love* EP in 1994; Red Jerry’s long-form Journey Into Dub is widely circulated on compilations and trance heritage sets.",
-  "synths": ["Echoing rave pads", "dub-style ambient synths", "hardcore stab variations"],
-  "drums": ["Rolled breakbeats", "heavy use of delay and reverb", "minimal melodic motifs"],
-  "influences": ["UK hardcore/dub crossover", "early jungle ambience", "rave-era dub aesthetics"],
-  "genre": "Breakbeat Hardcore",
-  "subgenre": "Dub-style Rave",
-  "youtube": ["https://www.youtube.com/watch?v=5XRtDFMlazA"]
-   },
-    {
-  "id": "binary-finary-1998-kay-cee-1999-radio-mix",
-  "title": "1998 (Kay Cee 1999 Radio Mix)",
-  "artist": "Binary Finary",
-  "tags": ["trance", "uplifting trance", "1999", "UK", "Kay Cee Remix"],
-  "description": "Originally produced as the iconic instrumental “1998” (1997/98), Binary Finary’s *1999 Radio Mix* by Dutch DJ‑producer Kay Cee condenses the epic melody into a tight 3:07 radio format. Crisp arpeggiated leads, dreamy chord pads, and emotional breakdowns give way to a soaring populated climax—all staged against a polished yet urgent tempo (~134 BPM). The Radio Mix brought mainstream accessibility to what was already one of the most beloved trance anthems of its era.",
-  "releaseYear": 1999,
-  "label": "Armada Music (1998 – Remixes)",
-  "album": "1998 – Remixes",
-  "country": "UK / Netherlands",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Binary Finary"],
-  "chartInfo": "Part of the official *1998 Remixes* release (Armada, 1999), along with Gouryella, Paul van Dyk, and other mixes; streamed widely across radio and trance compilations in late 1999–2000.",
-  "synths": ["Classic uplifting trance arp synths", "dreamy saw‑wave pads"],
-  "drums": ["Four‑on‑the‑floor kick", "shuffled trance hats", "wide snare rolls"],
-  "influences": ["Uplifting 90s trance era", "anthemic melodies of early‑2000s", "melodic trance pioneers"],
-  "genre": "Trance",
-  "subgenre": "Uplifting / Anthemic Trance",
-  "youtube": ["https://www.youtube.com/watch?v=FeYmMPaj5Vc"]
-   },
-   {
-  "id": "lost-witness-happiness-happening-lange-remix",
-  "title": "Happiness Happening (Lange Remix)",
-  "artist": "Lost Witness",
-  "tags": ["trance", "vocal trance", "1999", "UK", "Lange Remix"],
-  "description": "Released in early 1999, Lange’s remix of Lost Witness’s *Happiness Happening* transforms the original club classic into a soaring vocal trance anthem. Clocking approximately 7:15 in its extended form, the remix overlays lush, emotional vocals (by Tracey Carmen) atop expansive trance stabs, arpeggiated pads, and driving 138 BPM energy. Lange restructures the track into euphoric build-ups, oceanic breakdowns, and powerful drop sections—with atmospheric risers and shimmering synths that elevate it from vocal-house into trance legend. It received major club play across Europe and was frequently featured on trance compilations and radio playlists.",
-  "releaseYear": 1999,
-  "label": "Armada Music / Ministry of Sound (1999 remixes)",
-  "album": "Remixes Volume (Various releases)",
-  "country": "UK",
-  "artistBorn": "Simon Paul (Lost Witness)",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Dusk Til Dawn", "The Eden Project"], 
-  "chartInfo": "Remix of the original single (UK #18 in 1999), widely played across UK and European trance radio. Liebti track in late‑90s trance compilations and A State of Trance Classics sets.",
-  "synths": ["Atmospheric trance pads", "classic 90s trance arps", "vocal-driven synth waves"],
-  "drums": ["Rolling four‑on‑the‑floor kick", "layered trance snare/claps", "syncopated hats"],
-  "influences": ["1990s melodic vocal trance", "progressive build and drop structure", "Lange’s signature euphoric style"],
-  "genre": "Trance",
-  "subgenre": "Vocal Uplifting Trance",
-  "youtube": ["https://www.youtube.com/watch?v=jYsfR7e4gHI"]
-   },
-   {
-  "id": "crashforce-re-energize",
-  "title": "Re‑Energize",
-  "artist": "Crashforce",
-  "tags": ["acid trance", "hard trance", "1997", "Germany", "Crashforce"],
-  "description": "Released in 1997 on the vinyl 12″ *Re‑Energize* via Acid Trance Germany (ATH 012), “Re‑Energize” by Crashforce is a high‑octane acid‑trance track packed with snapping TB‑303 lines, industrial percussion textures, and driving, hypnotic rhythm—about 5:05 in length. It embodies the darker, harder edge of late‑’90s European acid‑trance, with metallic acid hits and relentless groove, making it a favorite among underground DJ sets and trance collectors.",
-  "releaseYear": 1997,
-  "label": "Acid Trance Germany (ATH 012)",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A‑side track of the *Re‑Energize* 12″; widely circulated in acid‑trance vinyl collections and later digital archives.",
-  "synths": ["Roland TB‑303 acid sequences", "metallic percussion stabs"],
-  "drums": "Hard kicks, acid percussion loops, gated hi‑hats",
-  "influences": ["German underground acid/hard trance", "mid-90s techno‑trance crossover"],
-  "genre": "Trance",
-  "subgenre": "Acid / Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=D0UF5-NyIGU"]
-   },
-   {
-  "id": "dj-warlock-the-energy",
-  "title": "The Energy",
-  "artist": "DJ Warlock",
-  "tags": ["acid trance", "1997", "Belgium", "Warlock"],
-  "description": "Released in 1997 on the *Energetik EP* (Buddja BUDD 012) via Belgium’s Buddja label, “The Energy” is an intense acid‑trance cut characterized by deep, rolling TB‑303 basslines, atmospheric pads, and hypnotic four-on‑the‑floor drive across ~8:01 minutes. The track’s tension builds through echoic sweeps and acid stabs, exemplifying late‑90s continental trance — raw yet cinematic. A true underground classic, it became widely shared among DJ sets emphasizing that era’s European acid-trance sound.",
-  "releaseYear": 1997,
-  "label": "Buddja Records (Energetik EP, BUDD 012)",
-  "album": "Energetik EP",
-  "country": "Belgium",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "A‑side lead track on the *Energetik EP* (BUDD 012); alongside *Hallucination* and *Urban Ritual*, it's regularly included in retrospective acid‑trance archives.",
-  "synths": ["Roland TB‑303 acid bass", "ambient trance pads"],
-  "drums": ["Steady 4/4 kick", "acid percussion loops", "reverb-laced hats"],
-  "influences": ["Belgian acid‑trance mid‑’90s", "underground trance energy", "deep cosmic textures"],
-  "genre": "Trance",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=o1VWr7QhrUw"]
-   },
-   {
-  "id": "cj-bolland-sugar-is-sweeter-armand-mix",
-  "title": "Sugar Is Sweeter (Armand Van Helden’s Drum ’n’ Bass Mix)",
-  "artist": "C.J. Bolland",
-  "tags": ["speed garage", "1996", "Belgium/UK", "Armand Van Helden", "club classic"],
-  "description": "Armand Van Helden’s remix of C.J. Bolland’s 1996 single “Sugar Is Sweeter” — official A‑side on vinyl and CD releases — became a seminal club anthem. Although titled a “Drum ’n’ Bass Mix,” it aligns more with the speed‑garage aesthetic of the era, featuring swung, skippy beats, dist‑orted bass and chopped-up vocals. The 8:32 version became widely circulated in 1996‑97 club sets and compilations.",
-  "releaseYear": 1996,
-  "label": "Internal/PolyGram / FFRR",
-  "album": null,
-  "country": "Belgium / UK",
-  "artistBorn": "1971-06-18",
-  "artistPrimaryGenre": "Electronic / Techno",
-  "aliases": ["Christian Jay Bolland"],
-  "chartInfo": "Hit #1 on U.S. Billboard Hot Dance Club Play and reached #11 on UK Singles Chart in 1996 (original version) — the remix drove much of this chart success.",
-  "synths": ["Filtered synth bass", "distorted vocal FX"],
-  "drums": ["Syncopated speed‑garage drums", "swing‑based skippy hi‑hats", "heavy kick"],
-  "influences": ["UK speed garage", "mid‑’90s club house", "Van Helden’s remix style"],
-  "genre": "Electronic",
-  "subgenre": "Speed Garage",
-  "youtube": ["https://www.youtube.com/watch?v=d_pJdQGSOCo"]
-   },
-   {
-  "id": "untidy-djs-funky-groove-rhythm-masters-sub-club-mix",
-  "title": "Funky Groove (Rhythm Masters Sub Club Mix)",
-  "artist": "Untidy DJ’s (Paul Janes)",
-  "tags": ["funky house", "1998", "UK", "Rhythm Masters", "Untidy Trax"],
-  "description": "A bouncy rework by the Rhythm Masters of Paul Janes’ 'Funky Groove' released originally on Untidy Trax and reissued via Manifesto. This Sub Club Mix leans into funky-house energy with crisp disco‑punch kicks, tight basslines, chopped vocals, and club‑ready groove across ~7:08 minutes.",
-  "releaseYear": 1998,
-  "label": "Manifesto Records / Untidy Trax",
-  "album": "Untidy Dubs Presents Funky Groove",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["Untidy Dubs"],
-  "chartInfo": null,
-  "synths": ["Funky bass stabs", "disco‑style chords"],
-  "drums": ["Punched four‑on‑the‑floor kick", "syncopated hi‑hats and snares"],
-  "influences": ["UK funky‑house", "90s disco‑house fusion"],
-  "genre": "House",
-  "subgenre": "Funky House",
-  "youtube": ["https://www.youtube.com/watch?v=LH14zW-Lhng"]
-   },
-   {
-  "id": "untidy-djs-funky-groove-rhythm-masters-sub-club-mix",
-  "title": "Funky Groove (Rhythm Masters Sub Club Mix)",
-  "artist": "Untidy DJ’s",
-  "tags": ["funky house", "1998", "UK", "Rhythm Masters", "Untidy Dubs"],
-  "description": "A club‑oriented rework by Rhythm Masters (Robert Chetcuti & Steve Mac) of Paul Janes’ 'Funky Groove' originally released on Untidy Trax. This Sub Club Mix delivers crisp disco‑funk kicks, tight basslines, chopped vocal tags, and a groovy, funky‑house swing in about ~6:55 minutes.",
-  "releaseYear": 1998,
-  "label": "Manifesto Records / Untidy Trax",
-  "album": "Untidy Dubs Presents Funky Groove",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["Untidy Dubs"],
-  "chartInfo": null,
-  "synths": ["Chopped vocal loops", "funky bass stabs"],
-  "drums": ["Four‑on‑the‑floor kick", "syncopated hi‑hats and snares"],
-  "influences": ["UK funky‑house", "90s disco‑house fusion"],
-  "genre": "House",
-  "subgenre": "Funky House",
-  "youtube": ["https://www.youtube.com/watch?v=LH14zW-Lhng"]
-   },
-   {
-  "id": "marco-v-indicator-original-mix",
-  "title": "Indicator (Original Mix)",
-  "artist": "Marco V",
-  "tags": ["hard trance", "2001", "UK", "Duty Free Recordings", "clubbing anthem"],
-  "description": "Marco V’s sizzling hard‑trance single “Indicator” originally released in 2001 on Duty Free Recordings. With its driving 4‑on‑the‑floor kick, soaring synth arpeggios, and crescendo builds, the track became a club mainstay across Europe. Clocking in around 7:09 minutes, it epitomizes early‑2000s European hard‑trance energy.",
-  "releaseYear": 2001,
-  "label": "Duty Free Recordings (DF 031)",
-  "album": null,
-  "country": "UK",
-  "artistBorn": "1967‑04‑26",
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["High‑energy trance arps", "anthemic lead synths"],
-  "drums": ["Driving four‑on‑the‑floor kick", "energetic hi‑hats/snare bounce"],
-  "influences": ["Early‑2000s hard trance", "Dutch trance club sound"],
-  "genre": "Trance",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=CFC04jptVOo"]
-   },
-   {
-  "id": "awesome-3-dont-go",
-  "title": "Don't Go",
-  "artist": "Awesome 3 ft. Julie McDermott",
-  "tags": ["90s house", "1992", "UK", "breakbeat house", "bleep house"],
-  "description": "“Don’t Go” by Awesome 3 featuring Julie McDermott is a defining track of early ’90s UK rave culture. Originally released in 1992 on Citybeat Records, the song fuses breakbeat-driven house with bleepy synths and soulful vocals. Its anthemic hook and genre‑blending structure made it a mainstay in underground rave sets and later in commercial club circuits. The 1996 reissue on XL Recordings gave the track new life, with remixes that brought it into the mainstream. A seminal blend of rave energy and emotional uplift.",
-  "releaseYear": 1992,
-  "label": "Citybeat Records (original); XL Recordings (1996 reissue)",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["Awesome 3", "The Awesome 3", "Awesome III", "A3"],
-  "chartInfo": "Reached #27 on the UK Singles Chart and #8 on the UK Dance Singles Chart in 1996 following reissue on XL Recordings.",
-  "synths": ["Bleep-style lead", "sub-bass", "rave stabs"],
-  "drums": ["Breakbeat groove", "punchy house kick", "syncopated snares"],
-  "influences": ["UK rave", "bleep house", "Detroit vocal house"],
-  "genre": "House",
-  "subgenre": "Bleep House / Breakbeat House",
-  "youtube": ["https://www.youtube.com/watch?v=1Dqm-6ghKS4"]
-   },
-   {
-  "id": "bk-revolution-original-mix",
-  "title": "Revolution (Original Mix)",
-  "artist": "BK",
-  "tags": ["hard house", "hard trance", "2002", "UK", "Nukleuz", "club anthem"],
-  "description": "One of the most iconic crossover hard‑house tracks, 'Revolution' by BK (Ben Keen) was released in 2002 on Nukleuz. Featuring a soaring synth lead, driving four‑on‑the‑floor rhythm, and euphoric breakdowns, it became a hard‑house anthem that even got daytime airplay on UK Radio 1. It’s considered a genre-defining anthem of the era.",
-  "releaseYear": 2002,
-  "label": "Nukleuz Records",
-  "album": null,
-  "country": "UK",
-  "artistBorn": "1977",
-  "artistPrimaryGenre": "Hard House",
-  "aliases": ["Ben Keen", "BK"],
-  "chartInfo": "Reached #42 on the UK Singles Chart and #1 on the UK Dance chart in 2002; last vinyl‑only release to chart in UK singles chart.",
-  "synths": ["Pumping lead synth riff", "anthemic arpeggios"],
-  "drums": ["Driving house kick", "fast hi‑hats clutch pattern"],
-  "influences": ["UK hard‑house", "early‑2000s rave/trance crossover"],
-  "genre": "Electronic",
-  "subgenre": "Hard House / Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=SZRsuvWxFzQ"]
-   },
-   {
-  "id": "todd-edwards-saved-my-life-original-mix",
-  "title": "Saved My Life (Original Mix)",
-  "artist": "Todd Edwards",
-  "tags": ["UK garage", "speed garage", "1995", "Nervous Records", "classic"],
-  "description": "Todd Edwards' breakthrough single “Saved My Life” (1995) is a landmark in UK garage/speed‑garage, built on his signature chopped-vocal mosaics over swinging four‑on‑the‑floor beats. It became a club staple in the UK underground and later reissued multiple times, notably by Defected Records in 2021.",
-  "releaseYear": 1995,
-  "label": "i! Records / Nervous (multiple reissues incl. 1995 & 2000)",
-  "album": null,
-  "country": "USA / UK",
-  "artistBorn": "1972‑12‑09",
-  "artistPrimaryGenre": "Garage house",
-  "aliases": ["The Messenger", "The Sample Choir", "Sunshine Bros."],
-  "chartInfo": "Original release became a UK club favourite; remixes and reissues helped cement its influence on early UK garage.",
-  "synths": ["Vocal chopped stabs", "sub‑bass pads"],
-  "drums": ["Swing‑inflected, shuffling 4/4 kick", "syncopated hats/snare"],
-  "influences": ["UK garage pioneering", "vocal sample collage technique", "early New York house influences"],
-  "genre": "House",
-  "subgenre": "UK Garage / Speed Garage",
-  "youtube": ["https://www.youtube.com/watch?v=r8uKbprFjIE"]
-   },
-   {
-  "id": "freefall-skydive-i-feel-wonderful-original-mix",
-  "title": "Skydive (I Feel Wonderful) (Original Mix)",
-  "artist": "Freefall feat. Jan Johnston",
-  "tags": ["trance", "1998", "UK", "Freefall", "Jan Johnston"],
-  "description": "Pioneering trance anthem featuring Jan Johnston’s ethereal vocals, written over the instrumental by trance producers Freefall (Alan Bremner & Anthony Pappa). Originally released in 1998, this lush trance cut blends shimmering arps, emotional pad work, and a cascade of vocals. Reissued in 2000 and 2001, it peaked at UK #35 on its third release.",
-  "releaseYear": 1998,
-  "label": "Stress Records (UK)",
-  "album": null,
-  "country": "UK / Australia",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": "UK Singles Chart: originally #75 in 1998, re‑entered at #43 (2000) and peaked at #35 (2001) :contentReference[oaicite:1]{index=1}",
-  "synths": ["Atmospheric arps", "emotive trance pads"],
-  "drums": ["Steady 4/4 kick", "sparse trance hats"],
-  "influences": ["Late‑90s UK trance", "vocal-driven emotional trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=S_zJtYD3vgo"]
-   },
-   {
-  "id": "kerri-chandler-bar-a-thym-extended-mix",
-  "title": "Bar A Thym (Extended Mix)",
-  "artist": "Kerri Chandler",
-  "tags": ["deep house", "2005", "UK", "Beat Music Fund", "club classic"],
-  "description": "A deep‑house masterclass from Kerri Chandler, originally released on *Bar A Thym / Sunshine & Twilight* (2005). The Extended Mix runs about ~7:24 and showcases Chandler’s signature blend of hypnotic chord stabs, rich piano motifs, deep basslines, and a steadily evolving groove—trusted in his DJ sets and underground club sound systems.",
-  "releaseYear": 2005,
-  "label": "Beat Music Fund (NRK imprint)",
-  "album": null,
-  "country": "UK / US",
-  "artistBorn": "1969‑09‑28",
-  "artistPrimaryGenre": "Deep House",
-  "aliases": ["Kerri Chandler", "Third Generation"],
-  "chartInfo": null,
-  "synths": ["Warm piano chords", "atmospheric deep house pads"],
-  "drums": ["Soft four‑on‑the‑floor kick", "swing hi‑hats and percussion elements"],
-  "influences": ["New Jersey deep house tradition", "early King Street / Nite Grooves era"],
-  "genre": "House",
-  "subgenre": "Deep House",
-  "youtube": ["https://www.youtube.com/watch?v=9UO06d9qsLQ"]
-   },
-   {
-  "id": "golden-girls-kinetic-99-commies-remix",
-  "title": "Kinetic ’99 (Commie’s Remix)",
-  "artist": "Golden Girls",
-  "tags": ["trance", "1999‑2000", "UK", "Commie", "Kinetic"],
-  "description": "A driving trance remix of Golden Girls’ original 'Kinetic', updated in 1999/2000 by the producer Commie. The mix delivers layered trance arps, sweeping pads, and a solid club tempo hovering around 6:00–6:02 minutes, often featured in trance DJ sets and compilations of the era.",
-  "releaseYear": 2000,
-  "label": "Vinyl release ‘Kinetic ’99’ series",
-  "album": "Kinetic ’99 The Remixes",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["Arpeggiated trance synths", "wide pad textures"],
-  "drums": ["Uplifting 4/4 kick", "subtle hi‑hat groove"],
-  "influences": ["Late‑90s UK trance", "remix culture"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=oDNBPPjcJPk"]
-   },
-   {
-  "id": "cortina-music-is-moving-bk-dbm-amber-mix",
-  "title": "Music Is Moving (BK & dBm Amber Mix)",
-  "artist": "Cortina",
-  "tags": ["hard house", "1999‑2000", "UK", "BK & dBm", "Nukleuz"],
-  "description": "A powerful hard‑house remix of Cortina’s original 'Music Is Moving', reworked in 1999‑2000 by producers BK & dBm Amber. The mix features heavy pumping basslines, energetic synth stabs, and DJ‑ready breakdowns—running about ~7:40 minutes on vinyl. A staple in late‑90s UK club and hard‑house sets.",
-  "releaseYear": 1999,
-  "label": "Nukleuz Records (NUKP 0159)",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard House",
-  "aliases": ["Cortina (UK hard house)"],
-  "chartInfo": null,
-  "synths": ["Acid‑style stabs", "energetic hard house lead synth"],
-  "drums": ["Four‑on‑the‑floor beating kick", "fast hi‑hats and percussive claps"],
-  "influences": ["UK hard house", "late‑90s club energetics"],
-  "genre": "Electronic",
-  "subgenre": "Hard House",
-  "youtube": ["https://www.youtube.com/watch?v=4QcuzpxF-04"]
-   },
-   {
-  "id": "agent-00-the-magnificent-original-radio-edit",
-  "title": "The Magnificent (Original Radio Edit)",
-  "artist": "Agent 00",
-  "tags": ["speed garage", "1998", "UK", "Inferno Records", "Agent 00", "Age 00"],
-  "description": "Agent 00’s “The Magnificent” (Original Radio Edit, ~3:51) is a late‑’90s UK speed‑garage jam. Released on Inferno Records in 1998, it features chopped vocals, heavy sub‑bass, and rolling 2‑step rhythms that defined the sound. A shorter radio edit distilled for mainstream and club airplay, while the 12″ mix (~6:43) catered to DJs.",
-  "releaseYear": 1998,
-  "label": "Inferno Records (UK, CD single / 12″)",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["Agent 00", "Age 00"],
-  "chartInfo": null,
-  "synths": ["Sub‑bass wobble", "vocal chopped stabs"],
-  "drums": ["Shuffled 2‑step kick", "snappy claps and hats"],
-  "influences": ["UK speed garage", "late‑90s rave / bassline evolution"],
-  "genre": "House",
-  "subgenre": "Speed Garage",
-  "youtube": ["https://www.youtube.com/watch?v=xDi9L2h_sOE"]
-   },
-   {
-  "id": "ruff-driverz-waiting-for-the-sun-radio-edit",
-  "title": "Waiting for the Sun (Radio Edit)",
-  "artist": "Ruff Driverz",
-  "tags": ["trance", "1999", "UK", "Ruff Driverz", "Altra Moda Music"],
-  "description": "The Radio Edit of Ruff Driverz’s trance anthem “Waiting for the Sun,” released in 1999. A concise 3:08 version with a clean structure and vocal hook tailored for radio and single release, distinct from the longer Original Mix (~8:14) and Heliotropic Mix versions.",
-  "releaseYear": 1999,
-  "label": "Altra Moda Music / Inferno",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House / Trance",
-  "aliases": ["2000BC", "Transit"],
-  "chartInfo": "Peaked at UK #37 and US Dance Club Play chart #2 in 1999‑2000, their biggest hit.",
-  "synths": ["Bright trance arps", "uplifting pads"],
-  "drums": ["Steady 4‑on‑the‑floor kick", "clean hi‑hat pulses"],
-  "influences": ["Late‑90s vocal trance", "British house‑trance crossover"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=igjJ9kxGZEU"]
-   },
-   {
-  "id": "cj-bolland-camargue-original",
-  "title": "Camargue (Original)",
-  "artist": "C.J. Bolland",
-  "tags": ["progressive house", "techno", "1992", "Belgium / UK", "classic rave"],
-  "description": "A hypnotic, organ-driven techno‑classic from C.J. Bolland released in 1992 on R&S Records, featured on his album *The 4th Sign*. Built around a layered organ riff, pulsing bassline, and imbalanced percussive energy, “Camargue” became a staple of the early‑’90s Belgian and UK rave scene.",
-  "releaseYear": 1992,
-  "label": "R&S Records (RS 92024)",
-  "album": "The 4th Sign",
-  "country": "Belgium / UK",
-  "artistBorn": "1971‑06‑18",
-  "artistPrimaryGenre": "Electronic / Techno",
-  "aliases": ["BCJ", "Space Opera", "Pulse"],
-  "chartInfo": null,
-  "synths": ["Gated organ lead", "acid-influenced bass"],
-  "drums": ["Minimal techno kicks", "clever gated percussion, hi‑hats"],
-  "influences": ["Belgian techno", "early ’90s rave", "R&S Records electro‑techno"],
-  "genre": "Electronic",
-  "subgenre": "Techno / Progressive House",
-  "youtube": ["https://www.youtube.com/watch?v=RsrdANlEz8I"]
-   },
-   {
-  "id": "boccaccio-life-the-secret-wish-club-mix",
-  "title": "The Secret Wish (Original Club Mix)",
-  "artist": "Boccaccio Life",
-  "tags": ["trance", "1997‑1998", "Belgium", "club classic", "Euro trance"],
-  "description": "The Original Club Mix of “The Secret Wish” by Boccaccio Life is a mid‑late ’90s trance anthem from Belgium. It showcases lush pads, soaring arpeggios, and euphoric breakdowns—running about ~5:13 minutes. Widely featured in European DJ sets and later reissued, it crossed into UK dance charts.",
-  "releaseYear": 1997,
-  "label": "Dance Opera (Belgium)",
-  "album": null,
-  "country": "Belgium",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Adventure Boys", "Allegro", "Body Heat", "Buzzerr", "DJ Don & Svenson", "Leader Of The Nation", "Nightwatchers", "Party Freaks", "Strawberry Flavour"],
-  "chartInfo": "Reached UK Dance Singles Chart #31 in November 2002 following a reissue on NEO label DMX009.",
-  "synths": ["Arpeggiated trance synths", "wide pad textures"],
-  "drums": ["Steady 4/4 kick", "light hi‑hat syncopation"],
-  "influences": ["Late‑90s Belgian trance", "anthemic club trance sound"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Jemqf2UTesE"]
-   },
-   {
-  "id": "cj-bolland-the-prophet-original-1997",
-  "title": "The Prophet (Original 1997 Mix)",
-  "artist": "C.J. Bolland",
-  "tags": ["techno", "ハード techno", "1997", "UK/Belgium", "classic", "FFRR"],
-  "description": "A seminal late‑’90s techno/trance hybrid by C.J. Bolland, released as the lead track on the *The Prophet / Sugar Is Sweeter* single in 1997. It features spoken‑word samples (notably Willem Dafoe from *The Last Temptation of Christ*), pulsing riffs, and dark cinematic energy—long celebrated in underground club sets.",
-  "releaseYear": 1997,
-  "label": "FFRR / Internal / London Records",
-  "album": null,
-  "country": "Belgium / UK",
-  "artistBorn": "1971‑06‑18",
-  "artistPrimaryGenre": "Techno / Trance",
-  "aliases": ["BCJ", "Space Opera", "Pulse", "Cee‑Jay"],
-  "chartInfo": "Reached UK Singles Chart #19 in 1997 as a double A‑side with “Sugar Is Sweeter” ([officialcharts.com](https://www.officialcharts.com/songs/cj-bolland-the-prophet/)).",
-  "synths": ["Minimal pulsing techno synths", "cinematic vocal samples"],
-  "drums": ["Driving 4/4 kick", "tight claps and hats"],
-  "influences": ["Belgian techno scene", "cinematic techno-trance crossover", "sample-based motif"],
-  "genre": "Electronic",
-  "subgenre": "Techno / Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ukbRAgXZYtU"]
-   },
-   {
-  "id": "cj-bolland-counterpoint-original-mix",
-  "title": "Counterpoint (Original Mix)",
-  "artist": "C.J. Bolland",
-  "tags": ["techno", "1995", "Belgium / UK", "The Analogue Theatre", "classic"],
-  "description": "“Counterpoint” is a penetrating techno cut from C.J. Bolland’s 1996 LP *The Analogue Theatre*, originally released as a single/EP in 1995. Running around ~6:23, the track merges driving mechanical percussion, hypnotic arpeggiated synth lines, and a cold, energetic groove—representative of mid-’90s Belgian techno minimalism.",
-  "releaseYear": 1995,
-  "label": "London Records (part of *The Analogue Theatre* era)",
-  "album": "The Analogue Theatre",
-  "country": "Belgium / UK",
-  "artistBorn": "1971-06-18",
-  "artistPrimaryGenre": "Techno",
-  "aliases": ["BCJ", "Space Opera", "Pulse", "Cee‑Jay"],
-  "chartInfo": null,
-  "synths": ["Arpeggiated techno motifs", "cool staccato leads"],
-  "drums": ["Syncopated kick and claps", "machine-style hi-hat groove"],
-  "influences": ["Belgian techno of the mid‑90s", "minimal industrial textures", "Berlin‑style rhythm patterns"],
-  "genre": "Electronic",
-  "subgenre": "Techno",
-  "youtube": ["https://www.youtube.com/watch?v=K6WeV4UDpo0"]
-   },
-   {
-  "id": "cj-bolland-people-of-the-universe-original",
-  "title": "People Of The Universe (Original Mix)",
-  "artist": "C.J. Bolland",
-  "tags": ["techno", "1996", "Belgium / UK", "The Analogue Theatre", "progressive"],
-  "description": "A cosmic techno piece from C.J. Bolland’s 1996 album *The Analogue Theatre*. “People Of The Universe” features hypnotic arpeggios, evolving pads, and a cinematic atmosphere—running about ~6:53. Positioned among standout tracks like “Counterpoint” and “There Can Be Only One,” it helps define Bolland’s mid‑’90s signature sound.",
-  "releaseYear": 1996,
-  "label": "London Records / Internal / PolyGram",
-  "album": "The Analogue Theatre",
-  "country": "Belgium / UK",
-  "artistBorn": "1971‑06‑18",
-  "artistPrimaryGenre": "Techno / Electronic",
-  "aliases": ["BCJ", "Space Opera", "Pulse", "Cee‑Jay"],
-  "chartInfo": null,
-  "synths": ["Hypnotic arpeggiated synths", "spacey pads"],
-  "drums": ["Steady techno kick", "sparse percussion"],
-  "influences": ["Belgian techno mid‑’90s", "atmospheric minimalism"],
-  "genre": "Electronic",
-  "subgenre": "Techno / Progressive",
-  "youtube": ["https://www.youtube.com/watch?v=z9QBQ-Ca0NM"]
-   },
-   {
-  "id": "cj-bolland-desolate-1-original-mix",
-  "title": "Desolate 1 (Original Mix)",
-  "artist": "C.J. Bolland",
-  "tags": ["techno", "1999", "Belgium/UK", "FFRR", "acid techno"],
-  "description": "A relentless acid‑techno / hard‑techno banger from C.J. Bolland, originally issued in 1999 as the A‑side to the *Desolate 1 / The Tingler* single on FFRR / Essential. Roughly ~7:46, the track is built around pounding acid stabs, mechanical percussion, and a rugged, industrial edge—often featured in underground techno DJ sets.",
-  "releaseYear": 1999,
-  "label": "FFRR / Essential Recordings (EXXDJ 5, promo 12″)",
-  "album": null,
-  "country": "UK / Belgium",
-  "artistBorn": "1971‑06‑18",
-  "artistPrimaryGenre": "Techno",
-  "aliases": ["BCJ", "Space Opera", "Pulse", "Cee‑Jay"],
-  "chartInfo": null,
-  "synths": ["Acid‑style TB‑303 stabs", "industrial synth FX"],
-  "drums": ["Machine‑driven 4/4 kick", "metallic percussion loops"],
-  "influences": ["Late‑90s hard techno", "Belgian acid techno", "industrial club sound"],
-  "genre": "Electronic",
-  "subgenre": "Techno / Acid Techno",
-  "youtube": ["https://www.youtube.com/watch?v=ylQHzQII61w"]
-   },
-   {
-  "id": "cj-bolland-it-aint-gonna-be-me",
-  "title": "It Ain't Gonna Be Me",
-  "artist": "C.J. Bolland",
-  "tags": ["techno", "1999", "UK / Belgium", "Essential Recordings", "acid techno"],
-  "description": "An energetic acid techno track by C.J. Bolland released in 1999 on Essential Recordings. Known for its pulsating TB-303 bassline and driving percussion, this track exemplifies late 90s European techno underground.",
-  "releaseYear": 1999,
-  "label": "Essential Recordings",
-  "album": null,
-  "country": "UK / Belgium",
-  "artistBorn": "1971-06-18",
-  "artistPrimaryGenre": "Techno",
-  "aliases": ["Cee-Jay", "BCJ"],
-  "chartInfo": {"UK Singles Chart": 35},
-  "synths": ["TB-303 acid bassline", "analog synth leads"],
-  "drums": ["4/4 kick drum", "claps", "hi-hats"],
-  "influences": ["Belgian techno", "acid house", "late 90s underground techno"],
-  "genre": "Electronic",
-  "subgenre": "Techno / Acid Techno",
-  "youtube": ["https://www.youtube.com/watch?v=QxIjXleuL5k"]
-   },
-   {
-  "id": "english-muffin-the-honky-hardcore-1996",
-  "title": "The Honky (Hardcore 1996)",
-  "artist": "English Muffin",
-  "tags": ["hardcore", "1996", "UK", "Hardcore Underground", "breakbeat hardcore"],
-  "description": "A classic 1996 breakbeat hardcore track by English Muffin, featuring energetic breakbeats and rave synths that epitomize the mid-90s UK hardcore scene.",
-  "releaseYear": 1996,
-  "label": "Hardcore Underground",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hardcore",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["rave synth stabs", "acid basslines"],
-  "drums": ["breakbeat loops", "fast 4/4 kick"],
-  "influences": ["UK rave culture", "early hardcore", "breakbeat hardcore"],
-  "genre": "Electronic",
-  "subgenre": "Hardcore / Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=example"] 
-   },
-   {
-  "id": "mega-city-2-darker-side-of-evil",
-  "title": "Darker Side Of Evil",
-  "artist": "Mega City 2",
-  "tags": ["hardcore", "1994", "UK", "Industrial Strength Records", "hardcore techno"],
-  "description": "A dark and intense hardcore techno track released in 1994 by Mega City 2 on Industrial Strength Records. Known for its heavy beats and ominous atmosphere, it’s a classic of the hardcore techno genre.",
-  "releaseYear": 1994,
-  "label": "Industrial Strength Records",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hardcore",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["dark synth pads", "industrial basslines"],
-  "drums": ["hard 4/4 kick", "aggressive percussion"],
-  "influences": ["early hardcore techno", "industrial music", "90s rave"],
-  "genre": "Electronic",
-  "subgenre": "Hardcore / Hardcore Techno",
-  "youtube": ["https://www.youtube.com/watch?v=KxfLft7zyvg"]
-   },
-   {
-  "id": "dj-ham-jump-2-da-groove",
-  "title": "Jump 2 Da Groove",
-  "artist": "DJ Ham",
-  "tags": ["hardcore", "2005", "UK", "Blatant Beats", "happy hardcore"],
-  "description": "A high-energy happy hardcore track by DJ Ham, released in 2005 on Blatant Beats. Known for its uplifting melodies and fast-paced beats, it captures the essence of mid-2000s UK rave culture.",
-  "releaseYear": 2005,
-  "label": "Blatant Beats",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hardcore",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["synth leads", "rave stabs"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["UK rave culture", "happy hardcore", "breakbeat hardcore"],
-  "genre": "Electronic",
-  "subgenre": "Hardcore / Happy Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=gp9EpfRs1Yw"]
-   },
-   {
-  "id": "analoge-dynamix-a-syd-again-1994",
-  "title": "A-syd Again",
-  "artist": "Analoge Dynamix",
-  "tags": ["techno", "1994", "UK", "Industrial Strength Records", "hardcore techno"],
-  "description": "A raw and energetic techno track from 1994 by Analoge Dynamix, released on Industrial Strength Records. Known for its driving beats and intense synths, it’s a staple of early hardcore techno.",
-  "releaseYear": 1994,
-  "label": "Industrial Strength Records",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Techno",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["acid synth lines", "dark synth pads"],
-  "drums": ["hard 4/4 kick", "snappy snares", "metallic percussion"],
-  "influences": ["early hardcore techno", "industrial", "90s rave scene"],
-  "genre": "Electronic",
-  "subgenre": "Techno / Hardcore Techno",
-  "youtube": ["https://www.youtube.com/watch?v=U9jFi9GF1TY"]
-   },
-   {
-  "id": "liquid-sweet-harmony",
-  "title": "Sweet Harmony",
-  "artist": "Liquid",
-  "tags": ["hardcore", "1992", "UK", "XL Recordings", "breakbeat hardcore", "rave"],
-  "description": "“Sweet Harmony” by Liquid is an iconic 1992 breakbeat hardcore anthem that helped define the early UK rave scene. The track masterfully blends euphoric piano melodies with energetic breakbeats and lush vocal samples, creating a euphoric atmosphere that resonated across clubs and raves worldwide. Built around a catchy piano riff and soulful vocal snippets, it captures the emotional intensity and optimism that characterized early 90s rave culture. It was a pivotal release that bridged hardcore with more melodic and accessible sounds, influencing countless producers and continuing to be a beloved classic in electronic music history.",
-  "releaseYear": 1992,
-  "label": "XL Recordings",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat Hardcore",
-  "aliases": [],
-  "chartInfo": {"UK Singles Chart": 15},
-  "synths": ["piano riffs", "lush pads", "vocal samples"],
-  "drums": ["breakbeat loops", "snappy snares", "4/4 kick"],
-  "influences": ["early rave culture", "breakbeat hardcore", "acid house"],
-  "genre": "Electronic",
-  "subgenre": "Breakbeat Hardcore / Rave",
-  "youtube": ["https://www.youtube.com/watch?v=9YvX8hnkg8I"]
-   },
-   {
-  "id": "dr-base-original-oyster-hard-trance-1997",
-  "title": "Original Oyster",
-  "artist": "D.R. Base",
-  "tags": ["hard trance", "1997", "Netherlands", "Basic Beat Recordings", "trance"],
-  "description": "“Original Oyster” by D.R. Base is a quintessential hard trance track from 1997, released on Basic Beat Recordings. Featuring driving, hypnotic synth arpeggios and powerful, pulsating beats, the track captures the energy and intensity of late 90s European trance. With its layered melodic motifs and hard-hitting rhythm section, it remains a classic in the hard trance scene and a favorite among DJs and trance enthusiasts.",
-  "releaseYear": 1997,
-  "label": "Basic Beat Recordings",
-  "album": null,
-  "country": "Netherlands",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["hypnotic synth arpeggios", "layered melodic motifs"],
-  "drums": ["pulsating kicks", "driving percussion"],
-  "influences": ["late 90s trance", "European club scene"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]
-   },
-   {
-  "id": "lemon8-bells-of-revolution-steve-thomas-remix",
-  "title": "Bells of Revolution (Steve Thomas Remix)",
-  "artist": "Lemon8",
-  "tags": ["hard trance", "1997", "UK", "Tidy Trax", "neo rave"],
-  "description": "A defining hard trance anthem from 1997, 'Bells of Revolution' by Lemon8, remixed by Steve Thomas, encapsulates the euphoric and driving essence of late 90s UK rave culture. Released on Tidy Trax, the track features uplifting melodies, rolling basslines, and energetic synths, making it a staple in hard dance sets and a favorite among enthusiasts of the genre.",
-  "releaseYear": 1997,
-  "label": "Tidy Trax",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard Trance",
-  "aliases": [],
-  "chartInfo": {"UK Singles Chart": 76},
-  "synths": ["uplifting melodies", "energetic synths"],
-  "drums": ["rolling basslines", "4/4 kick", "claps", "hi-hats"],
-  "influences": ["UK rave culture", "hard trance", "neo rave"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance / Neo Rave",
-  "youtube": ["https://www.youtube.com/watch?v=ogmidR2HEEo"]
-   },
-   {
-  "id": "amorph-astronaut-hard-trance-1994",
-  "title": "Astronaut",
-  "artist": "Amorph",
-  "tags": ["hard trance", "1994", "Germany", "Forbidden Planet Records", "trance"],
-  "description": "“Astronaut” by Amorph is a classic hard trance track released in 1994 on Forbidden Planet Records. Featuring driving beats, soaring synth leads, and hypnotic melodies, this track captures the essence of early European trance music and remains a favorite among trance enthusiasts for its atmospheric depth and dancefloor energy.",
-  "releaseYear": 1994,
-  "label": "Forbidden Planet Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["soaring synth leads", "hypnotic melodies"],
-  "drums": ["driving beats", "steady kick"],
-  "influences": ["early trance", "European club scene", "90s rave culture"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=04_GOwn0Bpg"]
-   },
-   {
-  "id": "atb-dont-stop-bassliner-mix",
-  "title": "Don't Stop! (Bassliner Mix)",
-  "artist": "ATB",
-  "tags": ["trance", "1999", "Germany", "Kontor Records", "vocal trance"],
-  "description": "The 'Bassliner Mix' of 'Don't Stop!' by ATB offers a deeper, bass-driven interpretation of the original track. Released in 1999, this version emphasizes the rhythmic elements and provides a more underground feel while retaining the uplifting melodies that made the original a hit. It's a testament to ATB's versatility in producing different flavors of trance music.",
-  "releaseYear": 1999,
-  "label": "Kontor Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": "1973-02-26",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["André Tanneberger"],
-  "chartInfo": {"UK Singles Chart": 86, "UK Dance Singles Chart": 32, "UK Independent Singles Chart": 19},
-  "synths": ["deep basslines", "uplifting melodies"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["late 90s trance", "eurodance", "vocal trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance / Vocal Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ogmidR2HEEo"]
-   },
-   {
-  "id": "macrocosm-amplifier-hard-trance-1995",
-  "title": "Amplifier",
-  "artist": "Macrocosm",
-  "tags": ["hard trance", "1995", "Germany", "G.A.R. Records", "trance"],
-  "description": "Released in 1995 on G.A.R. Records, 'Amplifier' by Macrocosm is a quintessential hard trance track that encapsulates the raw energy and driving rhythms characteristic of mid-90s European trance. The track features pulsating basslines, hypnotic synths, and a relentless 4/4 kick, making it a staple in the hard trance scene and a favorite among DJs and enthusiasts alike.",
-  "releaseYear": 1995,
-  "label": "G.A.R. Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["hypnotic synths", "acid stabs"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["early hard trance", "90s rave culture", "European club scene"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=wAxHTwQ8GGI"]
-   },
-   {
-  "id": "warp-brothers-vs-aquagen-phatt-bass-aquagen-short-mix",
-  "title": "Phatt Bass (Aquagen Short Mix)",
-  "artist": "Warp Brothers vs. Aquagen",
-  "tags": ["hard trance", "2000", "Germany", "Dos Or Die Records", "trance"],
-  "description": "The 'Aquagen Short Mix' of 'Phatt Bass' by Warp Brothers vs. Aquagen delivers a high-energy, bass-driven hard trance experience. Released in 2000 on Dos Or Die Records, this track showcases the synergy between the German electronic duos, blending pulsating basslines with dynamic synths, making it a staple in early 2000s rave culture.",
-  "releaseYear": 2000,
-  "label": "Dos Or Die Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard Trance",
-  "aliases": [],
-  "chartInfo": {"UK Dance Singles Chart": 9},
-  "synths": ["dynamic synths", "bass-driven leads"],
-  "drums": ["pulsating basslines", "4/4 kick", "claps", "hi-hats"],
-  "influences": ["early 2000s rave culture", "hard trance", "German electronic scene"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=VPV78f9ptpo"]
-   },
-   {
-  "id": "a-man-possessed-black-white-knuckleheadz-remix",
-  "title": "Black & White (Knuckleheadz Remix)",
-  "artist": "A Man Possessed",
-  "tags": ["hard trance", "2001", "UK", "Dos Or Die Records", "trance"],
-  "description": "The 'Knuckleheadz Remix' of 'Black & White' by A Man Possessed delivers a high-energy, bass-driven hard trance experience. Released in 2001 on Dos Or Die Records, this track showcases the synergy between the UK electronic duo and the remixing prowess of Knuckleheadz, blending pulsating basslines with dynamic synths, making it a staple in early 2000s rave culture.",
-  "releaseYear": 2001,
-  "label": "Dos Or Die Records",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard Trance",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["dynamic synths", "bass-driven leads"],
-  "drums": ["pulsating basslines", "4/4 kick", "claps", "hi-hats"],
-  "influences": ["early 2000s rave culture", "hard trance", "UK electronic scene"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=CMePEJ4ghdw"]
-   },
-   {
-  "id": "phlash-get-a-life-frantic-theme",
-  "title": "Get A Life (Frantic Theme)",
-  "artist": "Phlash! feat. Steve Hill",
-  "tags": ["hard house", "2002", "UK", "Tripoli Trax", "trance"],
-  "description": "Released in August 2002 on Tripoli Trax, 'Get A Life (Frantic Theme)' by Phlash! featuring Steve Hill is a quintessential hard house track that encapsulates the raw energy and driving rhythms characteristic of early 2000s UK hard house. The track features a cheery piano melody and a vocal sample that may be meant ironically, making it a staple in the hard house scene and a favorite among DJs and enthusiasts alike.",
-  "releaseYear": 2002,
-  "label": "Tripoli Trax",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard House",
-  "aliases": [],
-  "chartInfo": {"UK Singles Chart": 79, "UK Dance Singles Chart": 22, "UK Independent Singles Chart": 12},
-  "synths": ["cheery piano melody", "synth stabs"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["early 2000s UK hard house", "Frantic club events", "UK rave culture"],
-  "genre": "Electronic",
-  "subgenre": "Hard House",
-  "youtube": ["https://www.youtube.com/watch?v=jh6kkMnp5Kc"]
-   },
-   {
-  "id": "joe-hunt-up-to-no-good",
-  "title": "Up To No Good",
-  "artist": "Joe Hunt",
-  "tags": ["bassline house", "2024", "UK", "Room Two Recordings", "club anthem"],
-  "description": "Released on August 2, 2024, 'Up To No Good' by Joe Hunt is a high-energy bassline house track that quickly gained traction in the UK club scene. With its infectious bassline and catchy hooks, the track showcases Joe Hunt's signature style, blending elements of UK garage and house. The single charted at #8 on the UK Singles Chart and #7 on the UK Singles Downloads Chart, reflecting its widespread popularity and DJ support.",
-  "releaseYear": 2024,
-  "label": "Room Two Recordings",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Bassline House",
-  "aliases": [],
-  "chartInfo": {"UK Singles Chart": 8, "UK Singles Downloads Chart": 7},
-  "synths": ["pulsating basslines", "synth stabs"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["UK garage", "bassline house", "club anthems"],
-  "genre": "Electronic",
-  "subgenre": "Bassline House",
-  "youtube": ["https://www.youtube.com/watch?v=loGTPHM9DPw"]
-   },
-   {
-  "id": "ian-m-annihilation",
-  "title": "Annihilation",
-  "artist": "Ian M",
-  "tags": ["hard house", "1998", "UK", "Trade Records", "trance"],
-  "description": "Released in 1998 on Trade Records, 'Annihilation' by Ian M is a quintessential hard house track that encapsulates the raw energy and driving rhythms characteristic of late 90s UK hard house. The track features pulsating basslines, hypnotic synths, and a relentless 4/4 kick, making it a staple in the hard house scene and a favorite among DJs and enthusiasts alike.",
-  "releaseYear": 1998,
-  "label": "Trade Records",
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard House",
-  "aliases": [],
-  "chartInfo": null,
-  "synths": ["hypnotic synths", "acid stabs"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["late 90s hard house", "UK rave culture", "Trade club nights"],
-  "genre": "Electronic",
-  "subgenre": "Hard House",
-  "youtube": ["https://www.youtube.com/watch?v=EHIdtWb_4LQ"]
-   },
-   {
-  "id": "ador-young-world-smokey-bubblin-b-remix",
-  "title": "Young World (Smokey Bubblin' B Remix)",
-  "artist": "A.D.O.R.",
-  "tags": ["UK Garage", "2023", "Weapons Records", "Smokey Bubblin' B", "bassline"],
-  "description": "Released on September 22, 2023, 'Young World (Smokey Bubblin' B Remix)' by A.D.O.R. is a high-energy UK Garage track that reimagines the original with a fresh, bassline-driven approach. Smokey Bubblin' B's remix brings a dynamic rhythm and infectious groove, making it a standout in the garage scene. The track has been well-received by DJs and listeners alike, charting in multiple DJ charts and playlists.",
-  "releaseYear": 2023,
-  "label": "Weapons Records",
-  "album": null,
-  "country": "USA",
-  "artistBorn": "1969-09-26",
-  "artistPrimaryGenre": "Hip Hop",
-  "aliases": ["Eddie Castellanos"],
-  "chartInfo": {
-    "Traxsource": {"chartPosition": 3, "date": "2023-09-28"},
-    "Beatport": {"chartPosition": 15, "date": "2023-11-30"}
+    "id": "english-muffin-the-honky-hardcore-1996",
+    "title": "The Honky (Hardcore 1996)",
+    "artist": "English Muffin",
+    "tags": [
+      "hardcore",
+      "1996",
+      "UK",
+      "Hardcore Underground",
+      "breakbeat hardcore"
+    ],
+    "description": "A classic 1996 breakbeat hardcore track by English Muffin, featuring energetic breakbeats and rave synths that epitomize the mid-90s UK hardcore scene.",
+    "releaseYear": 1996,
+    "label": "Hardcore Underground",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hardcore",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "rave synth stabs",
+      "acid basslines"
+    ],
+    "drums": [
+      "breakbeat loops",
+      "fast 4/4 kick"
+    ],
+    "influences": [
+      "UK rave culture",
+      "early hardcore",
+      "breakbeat hardcore"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hardcore",
+      "Breakbeat Hardcore"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=example"
+    ]
   },
-  "synths": ["deep basslines", "synth stabs"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["UK Garage", "Bassline", "Hip Hop"],
-  "genre": "Electronic",
-  "subgenre": "UK Garage",
-  "youtube": ["https://www.youtube.com/watch?v=rxJVdPrQRMA"]
-   },
-   {
-  "id": "art-of-trance-madagascar-ferry-corsten-remix",
-  "title": "Madagascar (Ferry Corsten Remix)",
-  "artist": "Art Of Trance",
-  "tags": ["trance", "1999", "UK", "Platipus Records", "progressive trance"],
-  "description": "Released in 1999 on Platipus Records, 'Madagascar (Ferry Corsten Remix)' by Art Of Trance is a seminal track in the progressive trance genre. The remix by Ferry Corsten brought a fresh, energetic vibe to the original, featuring uplifting melodies, driving basslines, and intricate synth work. This track became a staple in the trance community and is considered a classic in the genre.",
-  "releaseYear": 1999,
-  "label": "Platipus Records",
-  "album": null,
-  "country": "UK",
-  "artistBorn": "1973-12-04",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Art Of Trance", "Simon Berry"],
-  "chartInfo": {"UK Dance Singles Chart": 1},
-  "synths": ["uplifting melodies", "driving basslines", "intricate synth work"],
-  "drums": ["4/4 kick", "claps", "hi-hats"],
-  "influences": ["progressive trance", "UK rave culture", "Platipus Records sound"],
-  "genre": "Electronic",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=YipIMl3xpHg"]
-   },
-   {
-  "id": "nostrum-polaris",
-  "title": "Polaris",
-  "artist": "Nostrum",
-  "tags": ["hard trance", "1995", "Germany", "Time Unlimited", "acid trance"],
-  "description": "Released in 1995 on Time Unlimited, 'Polaris' by Nostrum (aka Bernd Augustinski) is a powerful and emotionally intense hard trance anthem. It combines high-BPM energy with shimmering arpeggios and acidic sequences, creating a euphoric, melancholic sound that became a staple in 90s underground trance scenes across Europe.",
-  "releaseYear": 1995,
-  "label": "Time Unlimited",
-  "album": "Nostrum EP 4",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["acid arpeggios", "melancholic pads", "resonant lead synths"],
-  "drums": ["fast 4/4 kick", "rolling snares", "open hi-hats"],
-  "influences": ["acid trance", "early techno", "emotional rave"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=D-gfTkk8Yj8"]
-   },
-   {
-  "id": "nostrum-blow-back-original",
-  "title": "Blow Back (Original)",
-  "artist": "Nostrum",
-  "tags": ["hard trance", "1996", "Germany", "Time Unlimited", "acid trance"],
-  "description": "Released around 1996 on Time Unlimited, 'Blow Back (Original)' by Nostrum (Bernd Augustinski) is a seminal hard trance track, featuring driving kicks, acid-laced leads, and moody atmosphere. Highly regarded among underground trance collectors and DJs.",
-  "releaseYear": 1996,
-  "label": "Time Unlimited",
-  "album": "Cologne EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["acid basslines", "moody pads", "arpeggiated leads"],
-  "drums": ["4/4 kick", "snappy snares", "open hi‑hats"],
-  "influences": ["acid trance", "early techno", "90s rave"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ejKCxSrfCm8"]
-   },
-   {
-  "id": "nostrum-night-in-motion-extended-mix",
-  "title": "Night In Motion (Extended Mix)",
-  "artist": "Nostrum",
-  "tags": ["trance", "2000", "Germany", "Time Unlimited", "extended mix"],
-  "description": "Released in 2000 on Time Unlimited, the 'Extended Mix' of “Night In Motion” by Nostrum (Bernd Augustinski) is a lush trance track featuring spacious atmospheric pads, driving rhythms, and evolving acid‑tinged leads. Its nearly seven‑minute duration made it a favorite for clubs and DJs.",
-  "releaseYear": 2000,
-  "label": "Time Unlimited",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["atmospheric pads", "acid‑tinged leads", "arpeggiated sequences"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["acid trance", "progressive trance", "2000s techno"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=uB7HfsBHvt8"]
-   },
-   {
-  "id": "nostrum-e-motion-original",
-  "title": "E‑Motion",
-  "artist": "Nostrum",
-  "tags": ["trance", "1997", "Germany", "Time Unlimited", "deep trance"],
-  "description": "Released in 1997 on Time Unlimited, 'E‑Motion' by Nostrum (Bernd Augustinski) is a deep yet euphoric trance track, featuring captivating melodic basslines and driving rhythms. It stands out on the ‘Parish Fair’ album for its emotional uplift and dancefloor energy.",
-  "releaseYear": 1997,
-  "label": "Time Unlimited",
-  "album": "Parish Fair",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["captivating melody", "deep bassline", "uplifting pads"],
-  "drums": ["4/4 kick", "snares", "hi‑hats"],
-  "influences": ["deep trance", "1990s German trance", "euphoric melodic style"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=q0Eqi7UxPCU"]
-   },
-   {
-  "id": "nostrum-seduction-original",
-  "title": "Seduction",
-  "artist": "Nostrum",
-  "tags": ["trance", "1994", "Germany", "Time Unlimited", "deep trance"],
-  "description": "Released in 1994 on Time Unlimited, ‘Seduction’ by Nostrum (Bernd Augustinski) is a profound trance track featuring deep hypnotic sequences, emotive pads, and a driving groove. Clocking in at just over seven minutes, the track solidified its place in the early German trance movement.",
-  "releaseYear": 1994,
-  "label": "Time Unlimited",
-  "album": "EP 3.1",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["hypnotic pads", "emotive leads", "understated arpeggios"],
-  "drums": ["4/4 kick", "snappy snares", "subtle hi‑hats"],
-  "influences": ["deep trance", "early 1990s German trance", "emotional techno"],
-  "genre": "Electronic",
-  "subgenre": "Deep Trance",
-  "youtube": ["https://www.youtube.com/watch?v=46KVBOLW9DI"]
-   },
-   {
-  "id": "nostrum-melodrama-original",
-  "title": "Melodrama",
-  "artist": "Nostrum",
-  "tags": ["trance", "2001", "Germany", "Time Unlimited", "extended mix"],
-  "description": "Released in 2001 on Time Unlimited, ‘Melodrama’ by Nostrum (Bernd Augustinski) is a lush, hypnotic trance track blending sweeping pads, emotive melodies, and driving rhythms. A standout from the *Last Exit → Trance* series, it's celebrated in underground trance circles.",
-  "releaseYear": 2001,
-  "label": "Time Unlimited",
-  "album": "Last Exit → Trance",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["sweeping pads", "emotive leads", "melodic arpeggio"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["2000s trance", "melodic trance", "German underground"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=jsf1NH5A3po"]
-   },
-   {
-  "id": "nostrum-monastery-original",
-  "title": "Monastery",
-  "artist": "Nostrum",
-  "tags": ["trance", "1996", "Germany", "Time Unlimited", "acid trance"],
-  "description": "Released in 1996 on Time Unlimited, “Monastery” by Nostrum (Bernd Augustinski) is a hypnotic acid‑tinged trance track. It blends brooding pads, reverberant arpeggios, and rolling driving rhythms into a moody and immersive listening experience—a classic of underground German trance.",
-  "releaseYear": 1996,
-  "label": "Time Unlimited",
-  "album": "Monastery EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Bernd Augustinski", "Nostrum"],
-  "chartInfo": null,
-  "synths": ["reverberant arpeggios", "brooding pads", "acid sequences"],
-  "drums": ["4/4 kick", "snappy snares", "open hi‑hats"],
-  "influences": ["acid trance", "mid‑90s German techno", "underground rave"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=-IxHMB3wczU"]
-   },
-   {
-  "id": "tc-pornstar-original",
-  "title": "Pornstar",
-  "artist": "TC",
-  "tags": ["drum and bass", "2008", "UK", "D‑Style Recordings", "feat. Hannah Collins"],
-  "description": "Released in October 2008 on D‑Style Recordings, “Pornstar” by TC (Tom Casswell), featuring vocals by Hannah Collins, is a gritty, high‑energy drum & bass track with explicit, edgy lyrics and rolling basslines. Often paired with the VIP of “Borrowed Time,” it became a cult favorite among DnB fans.",
-  "releaseYear": 2008,
-  "label": "D‑Style Recordings",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Drum and Bass",
-  "aliases": ["Tom Casswell", "TC", "Tommy Boy"],
-  "chartInfo": null,
-  "synths": ["dark pads", "repeating bass stabs", "edgy vocal samples"],
-  "drums": ["fast breakbeats", "rolling snares", "sub‑bass kick"],
-  "influences": ["UK hardcore DnB", "bristol rave scene", "explicit lyrical style"],
-  "genre": "Electronic",
-  "subgenre": "Drum and Bass",
-  "youtube": ["https://www.youtube.com/watch?v=0uXN2ZJQ5M4"]
-   },
-   {
-  "id": "liquid-phog-original",
-  "title": "Phog",
-  "artist": "Liquid",
-  "tags": ["breakbeat hardcore", "1992", "United Kingdom", "XL Recordings", "rave"],
-  "description": "Released in 1992 on XL Recordings, “Phog” by Liquid (Eamon Downes & Shane Henegan) is a high‑energy breakbeat hardcore track featuring rolling beats, euphoric synth stabs, and rave‑style vocal samples. It originally appeared as a B‑side to the breakthrough single “Sweet Harmony” and quickly became a cult favorite in early UK rave culture.",
-  "releaseYear": 1992,
-  "label": "XL Recordings",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat / Hardcore",
-  "aliases": ["Liquid", "Eamon Downes", "Shane Henegan"],
-  "chartInfo": null,
-  "synths": ["euphoric synth stabs", "rave vocal samples", "bass‑heavy riffs"],
-  "drums": ["fast breakbeats", "snappy snares", "shuffled kicks"],
-  "influences": ["UK rave", "breakbeat hardcore", "early 90s rave culture"],
-  "genre": "Electronic",
-  "subgenre": "Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=4AKMGlGuk_M"]
-   },
-   {
-  "id": "sonz-of-a-loop-da-loop-era-higher",
-  "title": "Higher",
-  "artist": "Sonz of a Loop Da Loop Era",
-  "tags": ["breakbeat hardcore", "1991", "UK", "Suburban Base", "hardcore rave"],
-  "description": "Released in 1991 on Suburban Base, “Higher” by Sonz of a Loop Da Loop Era (Danny Breaks) is a breakbeat‑driven hardcore rave anthem featuring chopped vocal samples, punchy piano stabs, and energetic rhythm. It served as the AA‑side to the hit “Far Out” and became iconic in early UK hardcore culture.",
-  "releaseYear": 1991,
-  "label": "Suburban Base Records",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat / Hardcore",
-  "aliases": ["Danny Breaks", "Sonz of a Loop Da Loop Era"],
-  "chartInfo": {"UK Singles Chart": null, "UK Dance Singles Chart": null},
-  "synths": ["piano stabs", "chopped vocal samples"],
-  "drums": ["fast breakbeats", "shuffled kicks", "snappy snares"],
-  "influences": ["UK rave culture", "early 90s hardcore", "hip hop sampling"],
-  "genre": "Electronic",
-  "subgenre": "Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=v5wvwaOVMds"]
-   },
-   {
-  "id": "dj-bjonik-potsdamer-platz-original",
-  "title": "Potsdamer Platz",
-  "artist": "DJ Bjonik",
-  "tags": ["trance", "2000", "Germany", "A45 Music", "classic trance"],
-  "description": "Released in 2000 on A45 Music, 'Potsdamer Platz' by DJ Bjonik is a deep, melodic trance track with spacious pads, euphoric arpeggios, and rolling rhythms. Its evocative title references the iconic Berlin square, creating a blend of urban atmosphere and emotional trance energy.",
-  "releaseYear": 2000,
-  "label": "A45 Music",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Bjonik", "Kai van Bjonik"],
-  "chartInfo": null,
-  "synths": ["euphoric arpeggios", "spacious pads", "melodic leads"],
-  "drums": ["4/4 kick", "rolling snares", "hi‑hats"],
-  "influences": ["German trance", "Berlin ambience", "early 2000s trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=evzONw637hg"]
-   },
-   {
-  "id": "amen-uk-passion-baby-doc-remix",
-  "title": "Passion (Baby Doc Remix)",
-  "artist": "Amen! UK",
-  "tags": ["acid trance", "1997", "UK", "Feverpitch", "trance"],
-  "description": "Released in January 1997 on the Feverpitch label, the 'Baby Doc Remix' of \"Passion\" by Amen! UK (Paul Masterson) revisits the original with an acid-tinged trance treatment. It delivers hypnotic 303 lines, driving trance beats, and trance‑era euphoric breakdowns—capturing late‑90s UK trance energy.",
-  "releaseYear": 1997,
-  "label": "Feverpitch",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Amen! UK", "Paul Masterson"],
-  "chartInfo": null,
-  "synths": ["acid‑line 303", "hypnotic pads", "euphoric leads"],
-  "drums": ["4/4 kick", "snappy snares", "rolling hi-hats"],
-  "influences": ["acid trance", "late‑90s UK trance", "rave culture"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=sgp9_f2NaJY"]
-   },
-   {
-  "id": "nemo-spacemaker-push-remix",
-  "title": "Spacemaker (Push Remix)",
-  "artist": "Nemo",
-  "tags": ["trance", "1999", "UK", "Eve Nova", "progressive trance"],
-  "description": "Released in 1999 on UK label Eve Nova, “Spacemaker (Push Remix)” by Nemo delivers soaring trance energy with crisp production, ethereal pads, and melodic arpeggios. A defining track in late‑90s progressive and uplifting trance scenes.",
-  "releaseYear": 1999,
-  "label": "Eve Nova (EVE NOVA 002)",
-  "album": "Spacemaker / Long Range",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Nemo"],
-  "chartInfo": null,
-  "synths": ["ethereal pads", "melodic arpeggios", "sweeping leads"],
-  "drums": ["steady 4/4 kick", "snappy snares", "rolling hi-hats"],
-  "influences": ["late 90s trance", "UK progressive trance", "push remix style"],
-  "genre": "Electronic",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=b4QO93ZI_xE"]
-   },
-   {
-  "id": "dj-hitch-hiker-abel-kain-twilight-zone-dumondt-remix",
-  "title": "Twilight Zone (Hitch Hiker & Dumondt Remix)",
-  "artist": "DJ Hitch Hiker vs. Abel & Kain",
-  "tags": ["trance", "1999", "Germany", "Velvet Vibe", "acid trance"],
-  "description": "Remixed in 1999 by Hitch Hiker & Dumondt, this version of “Twilight Zone” by DJ Hitch Hiker vs. Abel & Kain delivers lush acid‑tinged trance vibes—complete with hypnotic 303 lines, swirling pads, and an evocative late‑90s trance groove.",
-  "releaseYear": 1999,
-  "label": "Velvet Vibe Recordings",
-  "album": "Inside My Soul / Twilight Zone",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Hitch Hiker", "Abel & Kain", "Jacques Dumondt"],
-  "chartInfo": null,
-  "synths": ["acid‑line 303", "hypnotic pads", "swirling leads"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["acid trance", "late‑90s European trance", "Velvet Vibe sound"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=XN6ivOaRJ2g"]
-   },
-   {
-  "id": "astrobug-one-original",
-  "title": "One!",
-  "artist": "Astrobug",
-  "tags": ["trance", "1999", "UK", "Paradigm Shift", "acid trance"],
-  "description": "Released in 1999 on Paradigm Shift Recordings, “One!” by Astrobug (M. Miezavs & S. Hockey) blends acid‑trance energy with rolling hard‑trance rhythms. A cult favorite in underground trance circles, it’s celebrated for its hypnotic sequences and trippy atmosphere.",
-  "releaseYear": 1999,
-  "label": "Paradigm Shift Recordings",
-  "album": null,
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Astrobug", "M. Miezavs", "S. Hockey"],
-  "chartInfo": null,
-  "synths": ["acid riffs", "hypnotic pads", "trippy leads"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["acid trance", "hard trance", "late‑90s UK trance"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=4-IZ6RQWwYE"]
-   },
-   {
-  "id": "untouchable-warriors-no-pain-original",
-  "title": "No Pain",
-  "artist": "Untouchable Warriors",
-  "tags": ["trance", "1995", "Germany", "Frankfurt Beat Productions", "hard trance"],
-  "description": "Released in 1995 via Germany’s Frankfurt Beat Productions, “No Pain” by Untouchable Warriors (Massimo Vivona) is a driving, hard‑trance anthem featuring acidic 303 lines, hypnotic pads, and peak‑time energy—classic mid‑90s European trance.",
-  "releaseYear": 1995,
-  "label": "Frankfurt Beat Productions",
-  "album": "Never Die / No Pain",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Untouchable Warriors", "Massimo Vivona"],
-  "chartInfo": null,
-  "synths": ["acid arpeggios", "hypnotic pads", "euphoric stabs"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["hard trance", "1990s German trance", "underground rave"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=dpnOOVxDCwg"]
-   },
-   {
-  "id": "uct-mind-overflow-microbots-remix",
-  "title": "Mind Overflow (Microbots Remix)",
-  "artist": "U.C.T.",
-  "tags": ["trance", "1993", "Germany", "Time Unlimited", "acid trance"],
-  "description": "Originally released in 1993 on Time Unlimited within the ‘Stronglimited’ compilation series, this Microbots remix of “Mind Overflow” by U.C.T. (Joachim Keil, Miguel Abel, Konrad Best & Frank Rohnacher) features hypnotic acid‑line 303, pulsing pads, and a tight driving trance groove emblematic of early German trance.",
-  "releaseYear": 1993,
-  "label": "Time Unlimited",
-  "album": "Stronglimited (Various Artists)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["U.C.T.", "Microbots Remix"],
-  "chartInfo": null,
-  "synths": ["acid‑303 lines", "hypnotic pads", "atmospheric textures"],
-  "drums": ["4/4 kick", "tight snares", "open hi‑hats"],
-  "influences": ["early 90s trance", "acid trance", "German underground"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=lF428OMQg4o"]
-   },
-   {
-  "id": "caesar-t-energy-part-1",
-  "title": "T Energy (Part 1)",
-  "artist": "Caesar",
-  "tags": ["trance", "2000", "Germany", "Various Artists", "compilation"],
-  "description": "Originally released in 2000 via a various‑artists compilation, “T Energy (Part 1)” by Caesar is a trance track showcasing uplifting pads, rhythmic arpeggios, and classic early‑2000s club energy. Included on the CD compilation *Trance 100 9: Best Of The Best*, it captures the era’s peak trance vibe.",
-  "releaseYear": 2000,
-  "label": "Various Artists (Trance 100 9 compilation)",
-  "album": "Trance 100 9: Best Of The Best",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Caesar"],
-  "chartInfo": null,
-  "synths": ["uplifting pads", "arpeggiated melodies", "ambient stabs"],
-  "drums": ["steady 4/4 kick", "snappy snares", "open hi‑hats"],
-  "influences": ["late‑90s/early‑00s trance", "German club trance", "compilation culture"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=irZLwLDpinQ"]
-   },
-   {
-  "id": "french-traxx-maes-traxx-original",
-  "title": "Maes Traxx",
-  "artist": "French Traxx",
-  "tags": ["trance", "1994", "France", "Peek‑A‑Boo Records", "hard trance"],
-  "description": "Released in 1994 on Peek‑A‑Boo Records (catalog PK 70013), ‘Maes Traxx’ by French Traxx is an early hard‑trance track featuring acid‑tinged lead synths, driving 4/4 rhythms, and classic early‑’90s energy—a hidden gem in French trance for its energy and raw production.",
-  "releaseYear": 1994,
-  "label": "Peek‑A‑Boo Records",
-  "album": "Special Hardbeats",
-  "country": "France",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Frenchtraxx", "French Traxx"],
-  "chartInfo": null,
-  "synths": ["acid‑style lead synth", "staccato pads", "rave stabs"],
-  "drums": ["fast 4/4 kick", "snappy snares", "rolling hi‑hats"],
-  "influences": ["early hard trance", "French rave scene", "acid trance"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=qIVOm2W2Mew"]
-   },
-   {
-  "id": "baby-violent-inspiration-original",
-  "title": "Inspiration",
-  "artist": "Baby Violent",
-  "tags": ["hard trance", "1997", "Italy", "Go Ahead Records", "trance"],
-  "description": "Released in 1997 on Italy’s Go Ahead Records (catalog GOA 007), “Inspiration” by Baby Violent is a hard‑trance track driven by energetic acid riff lines, atmospheric pads, and euphoric breakdowns. A cult classic from Italian trance in the late 90s.",
-  "releaseYear": 1997,
-  "label": "Go Ahead Records",
-  "album": null,
-  "country": "Italy",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Baby Violent"],
-  "chartInfo": null,
-  "synths": ["acid riff lines", "atmospheric pads", "euphoric stabs"],
-  "drums": ["4/4 kick", "snappy snares", "rolling hi‑hats"],
-  "influences": ["Italian trance", "hard trance", "1990s rave"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=EHJzRZLlj78"]
-   },
-   {
-  "id": "sound-scape-deliorman-original",
-  "title": "Deliorman",
-  "artist": "Sound Scape",
-  "tags": ["progressive trance", "1996", "Germany", "Time Unlimited", "hypnotic trance"],
-  "description": "Released in 1996 on Time Unlimited, “Deliorman” by Sound Scape (Frank Thelen & Klaus Krumme) is a progressive trance gem with swirling pads, melodic atmospherics, and a hypnotic groove. A standout from the Deliorman EP, it's beloved in classic trance circles.",
-  "releaseYear": 1996,
-  "label": "Time Unlimited",
-  "album": "Deliorman EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Sound Scape", "SoundScape"],
-  "chartInfo": null,
-  "synths": ["swirling pads", "atmospheric leads", "melodic arpeggios"],
-  "drums": ["steady 4/4 kick", "rolling snares", "hi‑hats"],
-  "influences": ["progressive trance", "mid‑90s German trance", "deep club sounds"],
-  "genre": "Electronic",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=rvv3dVnAvjo"]
-   },
-   {
-  "id": "sienna-arcs-in-circles-original",
-  "title": "Arcs in Circles",
-  "artist": "Sienna",
-  "tags": ["trance", "1999", "UK", "Halogen", "progressive trance"],
-  "description": "Released in December 1999 on UK label Halogen (catalog HALO:001), “Arcs in Circles” by Sienna is a lush progressive trance track featuring swirling pads, euphoric arpeggios, and emotive atmospheres. It’s a standout from the overlooked *Hard Evidence* release and appreciated in classic trance collector circles.",
-  "releaseYear": 1999,
-  "label": "Halogen",
-  "album": "Hard Evidence",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Sienna"],
-  "chartInfo": null,
-  "synths": ["swirling pads", "euphoric arpeggios", "atmospheric leads"],
-  "drums": ["steady 4/4 kick", "rolling snares", "shuffled hi‑hats"],
-  "influences": ["progressive trance", "late‑90s UK trance", "Club Atlantis era"],
-  "genre": "Electronic",
-  "subgenre": "Progressive Trance",
-  "youtube": ["https://www.youtube.com/watch?v=qLd79cT9mcQ"]
-   },
-   {
-  "id": "eqt-far-beyond-grosser-club-mix",
-  "title": "Far Beyond (Grosser Club Mix)",
-  "artist": "EQT",
-  "tags": ["trance", "1997", "Germany", "Cosmic Cubes / Sub Terranean", "euphoric trance"],
-  "description": "Released in 1997 on the Sub Terranean/Cosmic Cubes compilation series, “Far Beyond (Grosser Club Mix)” by EQT (Martin “YOMC” Röth) is a driving trance anthem—packed with euphoric leads, sweeping pads, and uplifting energy, it became a staple in late‑90s trance sets.",
-  "releaseYear": 1997,
-  "label": "Cosmic Cubes / Sub Terranean",
-  "album": "Cosmic Cubes – A Cosmic Trance Compilation Vol. V",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["EQT", "Martin YOMC Röth"],
-  "chartInfo": null,
-  "synths": ["euphoric leads", "swirling pads", "uplifting arpeggios"],
-  "drums": ["steady 4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["late‑90s euphoric trance", "Cosmic Cubes compilations", "German trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=hf7isR5Lkzg"]
-   },
-   {
-  "id": "synergy-flash-light-extended-mix",
-  "title": "Flash Light (Extended Mix)",
-  "artist": "Synergy",
-  "tags": ["trance", "1996‑1997", "Belgium/France", "Bonka Records / Dance Pool", "classic trance"],
-  "description": "Released in the mid‑90s on Bonka Records (Belgium) and Dance Pool (France), the Extended Mix of “Flash Light” by Synergy is a driving trance cut featuring lush pads, euphoric arpeggios, and rolling rhythms. A cult classic from the vintage trance era often played by early Belgian/Dutch DJs.",
-  "releaseYear": 1996,
-  "label": "Bonka Records (BEL) / Dance Pool (FRA)",
-  "album": null,
-  "country": "Belgium / France",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Synergy"],
-  "chartInfo": null,
-  "synths": ["euphoric pads", "acid‑style arpeggios", "atmospheric leads"],
-  "drums": ["4/4 kick", "snappy snares", "rolling hi‑hats"],
-  "influences": ["early Belgian trance", "Euro‑trance mid‑90s", "rave ambience"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=AMsvxDpggMc"]
-   },
-   {
-  "id": "chris-c-jon-doe-mitsubishi-baby-eurotrance-mix",
-  "title": "Mitsubishi Baby (Eurotrance Mix)",
-  "artist": "Chris C & Jon Doe",
-  "tags": ["trance", "1999", "UK", "Endeavour Records", "hard trance"],
-  "description": "Released in 1999 on the UK’s Endeavour label (catalog ENDV002), the Eurotrance Mix of “Mitsubishi Baby” by Chris C & Jon Doe delivers driving hard/trance energy, euphoric arpeggios, and stadium-like synth stabs. Known in underground trance circles for its cinematic build‑up and dancefloor impact.",
-  "releaseYear": 1999,
-  "label": "Endeavour Records",
-  "album": "Mitsubishi Baby 12\"",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Chris C", "Jon Doe"],
-  "chartInfo": null,
-  "synths": ["euphoric arpeggios", "cinematic stabs", "anthemic leads"],
-  "drums": ["steady 4/4 kick", "snappy snares", "fast hi‑hats"],
-  "influences": ["late‑90s hard trance", "UK rave", "Eurotrance"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=hxGaJAwDu60"]
-   },
-   {
-  "id": "alpha-crime-follow-me-dj-mind-x-remix",
-  "title": "Follow Me (DJ Mind‑X Remix)",
-  "artist": "Alpha Crime",
-  "tags": ["dream trance", "uplifting trance", "1999", "Switzerland", "Harem Records", "melodic trance"],
-  "description": "Released in 1999 on Harem Records (catalog HAR 023‑6), the DJ Mind‑X Remix of “Follow Me” by Alpha Crime delivers soaring melodies, euphoric pads, and a floating club groove. It stands as a quintessential example of Swiss dream trance and was championed by Mind‑X in late‑90s trance circuits.",
-  "releaseYear": 1999,
-  "label": "Harem Records",
-  "album": "Follow Me 12\" Single",
-  "country": "Switzerland",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Alpha Crime"],
-  "chartInfo": null,
-  "synths": ["melodic arpeggios", "euphoric pads", "dreamy lead synths"],
-  "drums": ["4/4 kick", "soft snares", "open hi‑hats"],
-  "influences": ["Swiss trance", "dream trance", "late‑90s club trance"],
-  "genre": "Trance",
-  "subgenre": "Dream Trance",
-  "youtube": ["https://www.youtube.com/watch?v=teGEJpkk0As"]
-   },
-   {
-  "id": "jfs-praxis-saturn-mix",
-  "title": "Praxis (Saturn Mix)",
-  "artist": "JFS",
-  "tags": ["hard trance", "1998", "Germany", "Tunnel Records", "acid trance"],
-  "description": "Released December 28, 1998 on Tunnel Records (catalog TR 3034), “Praxis (Saturn Mix)” by JFS is a driving late‑90s hard trance cut, featuring pulsing acid lines, energetic breakdowns, and a high‑octane club vibe. A standout B‑side to the ‘Obsession’ release, it's known for its intensity and underground DJ appeal.",
-  "releaseYear": 1998,
-  "label": "Tunnel Records",
-  "album": "Obsession 12\" single",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["JFS"],
-  "chartInfo": null,
-  "synths": ["acid lines", "energetic pads", "driving lead synths"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["German hard trance", "acid trance", "late‑90s underground"],
-  "genre": "Trance",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ENo4yHisjJM"]
-   },
-   {
-  "id": "seraphim-codex-phantom-power-original",
-  "title": "Phantom Power",
-  "artist": "Seraphim Codex",
-  "tags": ["trance", "1994", "Croatia", "Loving Ed Records", "hard trance"],
-  "description": "Released in 1994 on Croatia’s Loving Ed Records (catalog L.E.R. 07), “Phantom Power” by Seraphim Codex is a hard‑trance gem—packed with manic acid sequences, atmospheric pads, and propulsive rhythms. A rare vinyl-only release cherished by trance collectors.",
-  "releaseYear": 1994,
-  "label": "Loving Ed Records",
-  "album": null,
-  "country": "Croatia",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Seraphim Codex", "Deity (producer alias)"],
-  "chartInfo": null,
-  "synths": ["acid 303 lines", "atmospheric pads", "moody lead sequences"],
-  "drums": ["4/4 kick", "snappy snares", "open hi‑hats"],
-  "influences": ["hard trance", "early‑90s acid trance", "underground European trance"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Ab0wSitgoEc"]
-   },
-   {
-  "id": "nymphomania-masturbation-maniac-alex-tune-remix",
-  "title": "Masturbation Maniac (Alex Tune Remix)",
-  "artist": "Nymphomania feat. Urban Baal",
-  "tags": ["acid trance", "1994", "Belgium/Netherlands", "DOS Records", "underground trance"],
-  "description": "Released in 1994 on DOS Records, the Alex Tune Remix of “Masturbation Maniac” by Nymphomania feat. Urban Baal delivers driving acid‑flavored trance with hypnotic 303 sequences, tight rhythms, and pulsing energy—a cult classic of early‑90s underground Euro trance.",
-  "releaseYear": 1994,
-  "label": "DOS Records",
-  "album": null,
-  "country": "Belgium/Netherlands",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Nymphomania feat. Urban Baal"],
-  "chartInfo": null,
-  "synths": ["acid 303 riffs", "hypnotic pads", "pulsing lead loops"],
-  "drums": ["fast 4/4 kick", "snappy snares", "rolling hi‑hats"],
-  "influences": ["early acid trance", "Belgian rave scene", "1990s underground trance"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=-ZMRAZU--9Y"]
-   },
-   {
-  "id": "cooky-old-damn-house-norman-pain-cutmix",
-  "title": "Old Damn House (Norman & Pain Cutmix)",
-  "artist": "Cooky",
-  "tags": ["trance", "1997", "Germany", "Drizzly / DOS Records", "hard trance"],
-  "description": "Released in 1997 on Germany's Drizzly label (catalog DRIZ9710/17) and also featured on the compilation *Club Base 2*, the Norman & Pain Cutmix of “Old Damn House” by Cooky is a high‑energy trance remix by Norman & DJ Pain—extending to ~8:04 minutes with chopped edits, driving rhythms, and acid-tinged motifs that made it a favorite in techno‑trance sets.",
-  "releaseYear": 1997,
-  "label": "Drizzly Records / DOS Records",
-  "album": "Old Damn House 12\" single",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Cooky"],
-  "chartInfo": null,
-  "synths": ["acid motifs", "chopped synth loops", "energetic stabs"],
-  "drums": ["4/4 kick", "snappy snares", "rolling hi‑hats"],
-  "influences": ["late‑90s hard trance", "German club trance", "Norman & Pain remix style"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=ov4YdF4mTNI"]
-   },
-   {
-  "id": "dark-at8-dreams-minimum-dream",
-  "title": "Dreams (Minimum Dream)",
-  "artist": "Dark A.T.8",
-  "tags": ["trance", "1996", "Germany", "Deep Zone Records", "hard trance", "minimum dream mix"],
-  "description": "Released in 1996 on Deep Zone Records, “Dreams (Minimum Dream)” by Dark A.T.8 is a tight, driving trance cut featuring minimal acid lines, hypnotic atmospherics, and punchy club energy. The remix stands apart with its stripped‑down structure and harder edge compared to the fuller ‘Maximum Dream’ version.",
-  "releaseYear": 1996,
-  "label": "Deep Zone Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Dark A.T.8", "Dark AT8"],
-  "chartInfo": null,
-  "synths": ["minimal acid stabs", "hypnotic pads", "subtle lead motifs"],
-  "drums": ["4/4 kick", "tight snares", "open hi‑hats"],
-  "influences": ["hard trance", "1990s European underground trance", "minimal trance"],
-  "genre": "Trance",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=nSGQbrbj4Sw"]
-   },
-   {
-  "id": "dark-at8-slave-2-the-rhythm-airplay-mix",
-  "title": "Slave 2 The Rhythm (Airplay Mix)",
-  "artist": "Dark A.T.8",
-  "tags": ["hard trance", "1995", "Germany", "Deep Zone Records", "airplay mix"],
-  "description": "Released in 1995 on Germany’s Deep Zone Records, the Airplay Mix of “Slave 2 The Rhythm” by Dark A.T.8 is a concise hard-trance version (~4:26) featuring truncated staccato vocal snippets, an energetic driving kick, and a polished radio-oriented structure—distinct from the longer Stakkato Mix.",
-  "releaseYear": 1995,
-  "label": "Deep Zone Records",
-  "album": "Slave 2 The Rhythm (12\" single)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Dark A.T.8"],
-  "chartInfo": null,
-  "synths": ["staccato vocal snippets", "acid-charged motifs", "energetic lead stabs"],
-  "drums": ["tight 4/4 kick", "quick snares", "open hi‑hats"],
-  "influences": ["mid‑90s German hard trance", "industrial vocal trance", "Radio Edit style"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=K4tMe3JklaA"]
-   },
-   {
-  "id": "stardust-music-sounds-better-with-you-radio-edit",
-  "title": "Music Sounds Better with You (Radio Edit)",
-  "artist": "Stardust",
-  "tags": ["French house", "1998", "France", "Roulé", "dance-pop"],
-  "description": "Released July 20, 1998 on Thomas Bangalter’s French label Roulé (later Virgin/Because), “Music Sounds Better with You (Radio Edit)” by Stardust (Alan Braxe, Thomas Bangalter, Benjamin Diamond) is a seminal French‑house anthem built around a filtered Chaka Khan “Fate” guitar loop, polished Rhodes chords, and minimal rhythmic accompaniment—capturing euphoric bliss in under 5 minutes.",
-  "releaseYear": 1998,
-  "label": "Roulé (Virgin/Because)",
-  "album": null,
-  "country": "France",
-  "artistBorn": null,
-  "artistPrimaryGenre": "House",
-  "aliases": ["Stardust"],
-  "chartInfo": {"UK Singles Chart": 2, "US Dance Club Play": 1},
-  "synths": ["filtered guitar loop", "Rhodes piano chords"],
-  "drums": ["steady kick", "claps", "hi‑hat groove"],
-  "influences": ["French touch", "disco sampling", "house soul"],
-  "genre": "Electronic",
-  "subgenre": "French House",
-  "youtube": ["https://www.youtube.com/watch?v=EvHzRASaCxs"]
-   },
-   {
-  "id": "baby-d-let-me-be-your-fantasy-radio-edit",
-  "title": "Let Me Be Your Fantasy (Radio Edit)",
-  "artist": "Baby D",
-  "tags": ["rave", "breakbeat hardcore", "1994", "UK", "Systematic", "happy hardcore"],
-  "description": "Originally released in 1992, Baby D’s “Let Me Be Your Fantasy” became a UK No. 1 hit upon its re‑release in November 1994 via Systematic Records. The Radio Edit (~3:52) captures the classic breakbeat hardcore energy melded with powerful diva vocals, massive pianos, and euphoric melody—a defining anthem of the UK rave era.",
-  "releaseYear": 1994,
-  "label": "Systematic (London Records)",
-  "album": "Deliverance",
-  "country": "United Kingdom",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Breakbeat / Rave",
-  "aliases": ["Baby D"],
-  "chartInfo": {"UK Singles Chart": 1, "UK Dance Singles Chart": 1, "Eurochart Hot 100": 5},
-  "synths": ["massive piano chords", "filtered pads"],
-  "drums": ["breakbeat kicks", "snappy snares"],
-  "influences": ["UK rave", "happy hardcore", "jungle-lite"],
-  "genre": "Dance",
-  "subgenre": "Breakbeat Hardcore",
-  "youtube": ["https://www.youtube.com/watch?v=tuC7MBmhR0A"]
-   },
-   {
-  "id": "tiga-zyntherius-sunglasses-at-night-radio-edit",
-  "title": "Sunglasses at Night (Radio Edit)",
-  "artist": "Tiga & Zyntherius",
-  "tags": ["electro house", "2001", "Canada/Finland", "Turbo Recordings", "electro"],
-  "description": "Released November 4, 2001 on Turbo Recordings, Tiga & Zyntherius’ cover of Corey Hart’s “Sunglasses at Night” became a breakthrough electro‑house single. The Radio Edit (~3:43) blends iconic synth riffing with dancefloor sensibility, and charted internationally as a modern electro anthem.",
-  "releaseYear": 2001,
-  "label": "Turbo Recordings",
-  "album": "Sunglasses at Night single",
-  "country": "Canada / Finland",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Electro House",
-  "aliases": ["Tiga", "Zyntherius"],
-  "chartInfo": {"UK Singles Chart": 25, "UK Dance Singles Chart": 2},
-  "synths": ["synth hook riff", "electro leads", "filtered pads"],
-  "drums": ["steady 4/4 kick", "claps", "tight hi‑hats"],
-  "influences": ["80s synth‑pop", "electro revival", "dancefloor house"],
-  "genre": "Electronic",
-  "subgenre": "Electro House",
-  "youtube": ["https://www.youtube.com/watch?v=vCcfVvU0G_M"]
-   },
-   {
-  "id": "dj-crack-space-people-2000-iridium-gold-mix",
-  "title": "Space People 2000 (Iridium Gold Mix)",
-  "artist": "DJ Crack",
-  "tags": ["trance", "2000", "Germany", "Full‑E Records", "acid trance", "Iridium Gold Mix"],
-  "description": "Released in 2000 on Full‑E Records (vinyl catalog FUE‑0038‑12) and featured in various German trance compilations, the “Iridium Gold Mix” of “Space People 2000” by DJ Crack presents a more atmospheric and acid‑tinged version with ethereal pads, rolling rhythms, and a hypnotic groove. It stands out among the remixes for its ambient trance qualities.",
-  "releaseYear": 2000,
-  "label": "Full‑E Records",
-  "album": "Space People 2000 Remixes",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Crack"],
-  "chartInfo": null,
-  "synths": ["acid-tinged pads", "atmospheric textures", "ambient arpeggios"],
-  "drums": ["4/4 kick", "syncopated snares", "rolling hi‑hats"],
-  "influences": ["German trance", "acid trance", "ambient trance"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=pcJiRKn4hUI"]
-   },
-   {
-  "id": "dj-crack-century-of-e-short-mix",
-  "title": "The Century Of E (Short Mix)",
-  "artist": "DJ Crack",
-  "tags": ["trance", "1995", "Germany", "Full‑E Records", "short mix"],
-  "description": "Released in 1995 on Full‑E Records, the “Short Mix” of “The Century Of E” by DJ Crack (Michael Baur) delivers a compact hard‑trance finale with acid motifs, rolling rhythm, and punchy energy—tailored for radio, promo, and DJ intro use.",
-  "releaseYear": 1995,
-  "label": "Full‑E Records",
-  "album": "The Century Of E (Single)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Crack", "Michael Baur"],
-  "chartInfo": null,
-  "synths": ["acid lines", "ambient stabs", "lead motifs"],
-  "drums": ["tight kick", "short snares", "open hi‑hats"],
-  "influences": ["German hard trance", "acid trance", "90s promo mix"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=B_wA4OXU2kg"]
-   },
-   {
-  "id": "planet-earth-vibration-cocain-remix",
-  "title": "Vibration (Cocain Remix)",
-  "artist": "Planet Earth",
-  "tags": ["acid trance", "1994", "Germany", "Planet Earth", "Cocain Remix"],
-  "description": "Released in 1994 on the Planet Earth Vibration EP (Germany), the Cocain Remix delivers a cinematic acid‑trance interpretation: swirling pads, 303‑style riffs, driving rhythms and sweeping atmospherics. It's an underground favorite among classic Trance vinyl collectors.",
-  "releaseYear": 1994,
-  "label": "Planet Earth",
-  "album": "Vibration EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Planet Earth"],
-  "chartInfo": null,
-  "synths": ["acid‑303 riffs", "swirling pads", "atmospheric leads"],
-  "drums": ["steady 4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["early German acid trance", "1990s underground trance"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=_1GmSXreqVM"]
-   },
-   {
-  "id": "cherry-moon-trax-house-of-house-secret-development-remix",
-  "title": "The House of House (Secret Development Remix)",
-  "artist": "Cherry Moon Trax (feat. Secret Development)",
-  "tags": ["trance", "1998‑2003", "Belgium", "Bonzai / Backcatalogue BVBA", "remix"],
-  "description": "The Secret Development Remix of “The House of House” by Cherry Moon Trax (Yves Deruyter, Axel Stephenson & Franky Kloëck) is a euphoric trance re‑interpretation with extended atmospherics and punchy 303 embellishments. At ~8:39, this remix became popular in Bonzai remix series of the early 2000s.",
-  "releaseYear": 2003,
-  "label": "Backcatalogue BVBA (Bonzai Remix Worx compilation)",
-  "album": "The House Of House (Remastered Remixes)",
-  "country": "Belgium",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Cherry Moon Trax", "Secret Development"],
-  "chartInfo": null,
-  "synths": ["acid‑303 riffs", "ethereal pads", "euphoric leads"],
-  "drums": ["4/4 kick", "rolling snares", "open hi‑hats"],
-  "influences": ["Belgian trance", "acid trance", "Bonzai remix culture"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=hUMrdx86HJ4"]
-   },
-   {
-  "id": "legend-b-lost-in-love-original",
-  "title": "Lost In Love (Original Mix)",
-  "artist": "Legend B.",
-  "tags": ["hard trance", "1994", "Germany", "3 Lanka Records", "classic trance anthem"],
-  "description": "Released in 1994 on German label 3 Lanka, “Lost In Love” by Legend B. became a defining hard trance anthem of the mid‑90s. With its soaring, euphoric lead melodies woven over driving acid-tinged basslines, cut with emotional female vocals and uplifting breakdowns, it captures the belonging and yearning of trance’s golden era. Its monumental chord progression and crescendoing structure made it a staple in trance mix sets and compilations—one fan hailed it as “Emotional, Uplifting and just wow.” on r/ClassicTrance. Despite being underground, it charted in the UK Top 75 upon release, cementing its status as a cult classic.",
-  "releaseYear": 1994,
-  "label": "3 Lanka",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Legend B."],
-  "chartInfo": {"UK Singles Chart": 42},
-  "synths": ["emotive lead melody", "acid bassline", "pad swells"],
-  "drums": ["steady 4/4 kick", "snappy snares", "rolling hi‑hats"],
-  "influences": ["German hard trance", "90s rave ethos", "uplifting trance"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Ije-r417EZc"]
-   },
-   {
-  "id": "traumatic-acid-voices-higher-mandala-remix",
-  "title": "Acid Voices (Higher) (Mandala Remix)",
-  "artist": "Traumatic",
-  "tags": ["acid trance", "1994", "Germany", "Noom Records", "Mandala Remix"],
-  "description": "Remixed in 1994 by Mandala (Commander Tom & Ray Boyé), the “Mandala Remix” of Traumatic’s *Acid Voices (Higher)* transforms the original into a lean, hypnotic acid‑trance weapon. With its sharp 303 lines, fast tempo (~135 BPM), and spare structure, it became a beloved underground classic, prevalent in hard‑trance and rave playlists of the mid‑90s.",
-  "releaseYear": 1994,
-  "label": "Noom Records",
-  "album": "Higher EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Traumatic"],
-  "chartInfo": null,
-  "synths": ["acid‑303 riffs", "sparse lead loops", "atmospheric stabs"],
-  "drums": ["steady 4/4 kick", "tight snares", "open hi‑hats"],
-  "influences": ["early German acid trance", "hard trance", "mid‑90s rave"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=FW0SegNkPos"]
-   },
-   {
-  "id": "alien-factory-beta-music-hangover-remix",
-  "title": "Beta Music (Hangover Remix)",
-  "artist": "Alien Factory",
-  "tags": ["acid trance", "1993", "Germany", "Generator Records", "Hangover Remix"],
-  "description": "Released around 1993–94 on Germany’s Generator Records, the “Hangover Remix” of “Beta Music” by Alien Factory (Frank Möbus / Alien Factory project) reimagines the original into a hypnotic acid-trance journey. With merciless 303 riffs, propulsive rhythms, and cavernous breakdowns laden with reverb and echo, it epitomizes early Frankfurt‑style trance. Fans recall its immersive tension — a track that blurs psychedelic edges with raving energy, earning underground acclaim across European rave circuits.",
-  "releaseYear": 1993,
-  "label": "Generator Records",
-  "album": "Beta Music (The Remixes)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Alien Factory"],
-  "chartInfo": null,
-  "synths": ["acid 303 riffs", "echoing pads", "hypnotic lead loops"],
-  "drums": ["steady 4/4 kick", "sharp snares", "rolling hi-hats"],
-  "influences": ["early German acid trance", "Frankfurt techno", "rave underground"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=IfFZJdzRoB0"]
-   },
-   {
-  "id": "quench-dreams-original-mix",
-  "title": "Dreams (Original Mix)",
-  "artist": "Quench",
-  "tags": ["trance", "1993", "Australia", "Infectious Records", "Dreams", "classic trance"],
-  "description": "“Dreams” is widely considered one of the earliest trance anthems. Written and produced by Australian artist Christopher J. Dolan (a.k.a. Quench), it was first released in November 1993 on the UK label Infectious Records. Blending proto‑trance synth arpeggios and emotive breakdowns over a steady 4/4 techno framework, it became a seminal underground hit across Europe, reaching #9 in France and #75 in the UK upon re‑release in 1994. Often credited as a turning point in rave culture, it helped define the emerging trance sound.",
-  "releaseYear": 1993,
-  "label": "Infectious Records",
-  "album": "Sequenchial",
-  "country": "Australia",
-  "artistBorn": "1960s‑? (Christopher J. Dolan)",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Christopher J. Dolan", "Quench"],
-  "chartInfo": {"France": "#9 (1994 re‑release)", "UK": "#75 (1994)"},
-  "synths": ["arpeggiated trance lead", "ambient pads", "acid‑style motifs"],
-  "drums": ["4/4 kick", "snare or clap on 2/4", "driving hi‑hats"],
-  "influences": ["early trance", "techno", "UK rave", "proto‑trance aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Early Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Xa_iOGzoY9A"]
-   },
-   {
-  "id": "commitee-trance-line-original-version",
-  "title": "Trance Line (Original Version)",
-  "artist": "Committee",
-  "tags": ["trance", "1994‑95", "Germany/France", "Full Ace Music", "hard trance", "sample‑based"],
-  "description": "“Trance Line” by Committee (sometimes spelled 'Commitee') is a hard‑trance track first issued on vinyl around 1994–95 via Full Ace Music (France/Germany). Built around a vocal sample from “So Get Up” by Underground Sound of Lisbon featuring Ithaka, the track combines driving 4/4 rhythms, acid-inflected synth stabs, and a cinematic breakdown that became popular in European rave circles.",
-  "releaseYear": 1995,
-  "label": "Full Ace Music / Ace Music",
-  "album": null,
-  "country": "France/Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Committee", "Commitee"],
-  "chartInfo": null,
-  "synths": ["acid-styled stab loops", "sampling of vocal vocals", "synthetic pads"],
-  "drums": ["steady 4/4 kick", "punchy snares", "driving hi-hats"],
-  "influences": ["hard trance", "techno", "sample‑based club tracks"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=RrgWXWJRvAk"]
-   },
-   {
-  "id": "dj-merlin-energizer-in-my-mind",
-  "title": "In My Mind (Original Mix)",
-  "artist": "DJ Merlin & Energizer",
-  "tags": ["trance", "hard trance", "late 1990s", "Spain", "classic trance"],
-  "description": "“In My Mind” is a high‑energy trance/hard‑trance track credited to DJ Merlin & Energizer, first appearing around 1999 on Spanish trance/makina compilations. Defined by hypnotic mounting synth loops, a driving 4/4 beat, and a repetitive melodic motif, it was featured on *The Tunnel E.P.* and *Pont Aeri Trilogy*, gaining traction in Spanish club and makina scenes.",
-  "releaseYear": 1999,
-  "label": null,
-  "album": "The New Project Vol. I, Session 2.1",
-  "country": "Spain",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Merlin", "Energizer"],
-  "chartInfo": null,
-  "synths": ["melodic motif loops", "atmospheric pads", "driving hard‑trance leads"],
-  "drums": ["steady 4/4 kick", "punchy snares", "energetic hi‑hats"],
-  "influences": ["Spanish makina scene", "late‑90s hard trance", "European club compilations"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance / Makina",
-  "youtube": ["https://www.youtube.com/watch?v=7vJ-FjsWiCU"]
-   },
-   {
-  "id": "jayc-gissa-underground-original",
-  "title": "Underground",
-  "artist": "JAYC & Gissa",
-  "tags": ["electronic", "2023", "JAYC Records", "House‑influenced", "club single"],
-  "description": "“Underground” is a solo single by JAYC and Gissa, released October 20, 2023 on JAYC label. The track blends electronic club rhythms, hypnotic synth patterns and vocal snippets into a sleek, modern house-electronic vibe. Clocking in at approximately 3:14, it showcases polished production and has been featured heavily on streaming platforms and playlists across the electronic scene.",
-  "releaseYear": 2023,
-  "label": "JAYC",
-  "album": "Underground – Single",
-  "country": null,
-  "artistBorn": null,
-  "artistPrimaryGenre": "Electronic",
-  "aliases": ["JAYC", "Gissa"],
-  "chartInfo": null,
-  "synths": ["rolled synth chords", "club bassline", "vocal stabs"],
-  "drums": ["steady 4/4 kick", "snappy claps", "grooving hi‑hats"],
-  "influences": ["modern house", "electro‑pop", "streaming‑era club sound"],
-  "genre": "Electronic",
-  "subgenre": "House / Electro",
-  "youtube": ["https://www.youtube.com/watch?v=4Izd38_w3WY"]
-   },
-   {
-  "id": "lostboyjay-could-be-wrong-original",
-  "title": "Could Be Wrong",
-  "artist": "LOSTBOYJAY",
-  "tags": ["deep house", "2022", "Canada", "Polydor Records", "sample‑based", "dance"],
-  "description": "“Could Be Wrong” is a deep‑house single by Canadian artist LOSTBOYJAY (Jay Daillie), released December 2 2022 via Polydor Records under license by Universal. Built on a creative, mid‑tempo interpolation of Brandy’s “I Wanna Be Down,” the track melds smooth vocals, rhythmic piano loops, and a rolling pulsating groove. It gained viral traction across TikTok and streaming playlists, helping solidify LOSTBOYJAY’s emergence in electronic/dance scenes.",
-  "releaseYear": 2022,
-  "label": "Polydor Records",
-  "album": "Could Be Wrong (Single)",
-  "country": "Canada",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Deep House",
-  "aliases": ["Jay Daillie", "LOSTBOYJAY"],
-  "chartInfo": null,
-  "synths": ["piano‑based chords", "vocal sample interpolation", "atmospheric pads"],
-  "drums": ["steady 4/4 kick", "soft snares/claps", "light hi‑hats"],
-  "influences": ["1990s R&B", "contemporary deep house", "viral dance‑pop aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Deep House",
-  "youtube": ["https://www.youtube.com/watch?v=CYAQEJyqR7E"]
-   },
-   {
-  "id": "bk-sam-townend-drop-to-your-knees-original",
-  "title": "Drop To Your Knees (Original Mix)",
-  "artist": "BK & Sam Townend",
-  "tags": ["hard house", "tech house", "2014‑15", "UK", "club single"],
-  "description": "“Drop To Your Knees” by BK & Sam Townend is a high‑energy hard‑house/tech‑house track, released around 2014–2015. Known within underground dance circuits, the track features a tight four‑on‑the‑floor beat, vocal chops commanding the dancefloor (“drop to your knees”), sharp stabs, and driving basslines. A staple on mix shows and DJ sets, it earned particular visibility via BK’s SLAM! remix variation.",
-  "releaseYear": 2014,
-  "label": null,
-  "album": null,
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard House",
-  "aliases": ["BK", "Sam Townend"],
-  "chartInfo": null,
-  "synths": ["staccato vocal chops", "acid‑style synth stabs", "dark bassline"],
-  "drums": ["4/4 kick", "snappy claps", "tech‑hi‑hats"],
-  "influences": ["UK hard house", "early tech‑house", "club dance production"],
-  "genre": "Electronic",
-  "subgenre": "Hard House / Tech‑House",
-  "youtube": ["https://www.youtube.com/watch?v=X2VZshi46NE"]
-   },
-   {
-  "id": "turbine3-die-macht-volle-kraft-voraus-aggressor-remix",
-  "title": "Die Macht! (‘Volle Kraft Voraus’ Remix By Aggressor)",
-  "artist": "Turbine 3",
-  "tags": ["acid trance", "1999", "Germany", "Time Motion Trance", "Aggressor Remix"],
-  "description": "An aggressive acid-trance rework of “Die Macht!” executed by Aggressor, released in 1999 under the Turbine 3 alias. The remix—titled “Volle Kraft Voraus”—appears on the Time Motion Trance 4 compilation, delivering punchy 303 lines, propulsive rhythms, and cinematic breakdowns characteristic of late-90s German acid trance.",
-  "releaseYear": 1999,
-  "label": "Time Motion Trance / compilation",
-  "album": "Time Motion Trance 4",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Turbine 3"],
-  "chartInfo": null,
-  "synths": ["acid 303 riffs", "deep bass resonance", "echoing pads"],
-  "drums": ["steady 4/4 kick", "claps/snare on 2‑4", "rolling hi‑hats"],
-  "influences": ["German acid trance", "hard trance aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=a6ZLSWu8NJ8"]
-   },
-   {
-  "id": "ppk-i-have-a-dream-original",
-  "title": "I Have a Dream",
-  "artist": "PPK",
-  "tags": ["trance", "2000", "Russia", "Perfecto Records", "Martin Luther King sample"],
-  "description": "“I Have a Dream” by Russian trance duo PPK (Sergey Pimenov & Alexander Polyakov) was released in 2000. It incorporates spoken-word samples from Martin Luther King Jr.’s iconic speech, layered over shimmering trance textures and emotive breakdowns. The nearly 9‑minute track (≈ 8:56) appears on their album *Russian Trance: Formation* and represents a pioneering Eastern‑European trance production.",
-  "releaseYear": 2000,
-  "label": "Perfecto Records / iRecords",
-  "album": "Russian Trance: Formation",
-  "country": "Russia",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["PPK"],
-  "chartInfo": null,
-  "synths": ["ethereal pads", "arpeggiated lead", "uplifting chords"],
-  "drums": ["steady 4/4 kick", "snare/clap on 2‑4", "rolling hi‑hats"],
-  "influences": ["Eastern‑European trance", "speech‑sample trance", "early 2000s melodic trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=RMpWHJYlfKY"]
-   },
-   {
-  "id": "paraphonatic-the-past-the-present-the-future-pure-nrg-remix",
-  "title": "The Past, the Present, the Future (DJ Mellow‑D’s Pure NRG Remix)",
-  "artist": "Paraphonatic",
-  "tags": ["trance", "1997‑2013", "Germany", "EDM Records", "Pure NRG Remix"],
-  "description": "A high‑energy trance re‑remix by DJ Mellow‑D—titled “Pure NRG Remix”—of Paraphonatic’s “The Past, the Present, the Future.” Originally released circa 1997 and officially re‑issued (remastered) in 2013 on EDM Records (catalog EDM 020), the remix is a driving trance anthem built around rising arpeggios, lush pads, and sweeping synth builds.",
-  "releaseYear": 1997,
-  "label": "EDM Records",
-  "album": "The Past, The Present, The Future (2013 Remastered Version)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Paraphonatic"],
-  "chartInfo": null,
-  "synths": ["arpeggiated trance lead", "lush pads", "energetic rising motifs"],
-  "drums": ["steady 4/4 kick", "snare/clap on 2‑4", "rolling hi‑hats"],
-  "influences": ["German trance", "energetic remix styles"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": []
-   },
-   {
-  "id": "paraphonatic-reincarnation-the-way-we-do-original",
-  "title": "Reincarnation (The Way We Do)",
-  "artist": "Paraphonatic",
-  "tags": ["hard trance", "1995", "Germany", "Wizard Records", "Reincarnation anthem"],
-  "description": "“Reincarnation (The Way We Do)” is the original anthem by Paraphonatic, released in 1995 on Wizard Records. Created as the official track for the Reincarnation Parade in Hannover, it features driving acid-style stabs, a relentless BPM, and a repeated vocal line (“the way we do”) that became emblematic of mid-'90s German hard trance. The track was heavily played in clubs and at major events, gaining underground popularity and inclusion in several high-profile compilations.",
-  "releaseYear": 1995,
-  "label": "Wizard Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard Trance",
-  "aliases": ["Paraphonatic"],
-  "chartInfo": { "German Dance Chart (DDC)": "#18 (1995, club rotation)" },
-  "synths": ["acid stabs", "vocal sample hook", "pulsing lead lines"],
-  "drums": ["fast 4/4 kick", "tight snares", "driving hi‑hats"],
-  "influences": ["German hard trance", "Reincarnation Parade culture", "anthemic event trance"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=WIVDqYeLAjg"]
-   },
-   {
-  "id": "paraphonatic-festival-of-the-century-riva-the-spaceman-remix",
-  "title": "Festival of the Century (Riva & The Spaceman Remix)",
-  "artist": "Paraphonatic",
-  "tags": ["trance", "1996", "Germany", "EDM Records", "Riva & The Spaceman Remix"],
-  "description": "This remix brings a driving trance reinterpretation of Paraphonatic’s “Festival of the Century” by Riva & The Spaceman. Originally released in 1996 on Wizard Records, then remastered and reissued in 2013 by EDM Records, the remix delivers emotional arpeggios, lush pads, and high‑energy rhythms typical of German trance.",
-  "releaseYear": 1996,
-  "label": "Wizard Records / EDM Records",
-  "album": "Festival of the Century (2013 Remastered Version) [Remixes] EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Paraphonatic"],
-  "chartInfo": { "Regional Charts": "Top 10 in Russia and Czech Republic under alias Calypso (1996)" },
-  "synths": ["arpeggiated lead", "pad swells", "uplifting trance motifs"],
-  "drums": ["steady 4/4 kick", "snare/clap on 2‑4", "syncopated hi‑hats"],
-  "influences": ["German trance style", "anthemic remix interpretation", "event-themed compositions"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=Pf6VV8q8Ces"]
-   },
-   {
-  "id": "paraphonatic-the-past-the-present-the-future-xtc-rave-mix",
-  "title": "The Past, the Present, the Future (XTC‑Rave Mix)",
-  "artist": "Paraphonatic",
-  "tags": ["trance", "1997", "Germany", "EDM Records", "XTC‑Rave Mix"],
-  "description": "A special remix crafted as the anthem for the Ex.TC Rave in Schwerin, Germany. Paraphonatic performed the XTC‑Rave Mix live at the event. Originally released in 1997 and remastered in 2013 on EDM Records, this version combines energetic trance riffs, arpeggiated motifs, and festival-ready atmosphere.",
-  "releaseYear": 1997,
-  "label": "EDM Records",
-  "album": "The Past, The Present, The Future (Remixes) EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Paraphonatic"],
-  "chartInfo": { "Regional Rave Anthem": "Ex.TC Rave anthem (1998) — official event anthem" },
-  "synths": ["arpeggiated trance lead", "energetic rhythm motifs", "uplifting trance pads"],
-  "drums": ["steady 4/4 kick", "snare/clap on 2‑4", "syncopated hi‑hats"],
-  "influences": ["German trance festival anthems", "energetic rave trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=tsbc4LoTjtY"]
-   },
-   {
-  "id": "dave-davis-transfiguration-original-mix",
-  "title": "Transfiguration (Original Mix)",
-  "artist": "Dave Davis",
-  "tags": ["trance", "hard trance", "1995", "Belgium", "Bonzai Records"],
-  "description": "“Transfiguration” is a seminal trance/hard‑trance anthem by Belgian producer Dave Davis (a.k.a. JD Davis), released in 1995 on Bonzai Records. Defined by soaring synth leads, sweeping pads, and a thunderous drive, it captured the euphoric spirit of mid‑90s trance and became a club favorite and mix-compilation staple.",
-  "releaseYear": 1995,
-  "label": "Bonzai Records",
-  "album": null,
-  "country": "Belgium",
-  "artistBorn": "1973‑04‑13 (David Henrard)",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Dave Davis", "JD Davis"],
-  "chartInfo": { "Belgian Dance Chart": "#18 (1995, Bonzai club circuit)" },
-  "synths": ["uplifting trance lead", "atmospheric pads", "driving arpeggios"],
-  "drums": ["steady 4/4 kick", "claps on 2‑4", "open hi‑hats"],
-  "influences": ["Belgian hard trance", "Bonzai sound", "mid‑90s euphoric trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=V4GOrRpxQ8Q"]
-   },
-   {
-  "id": "paragod-dj-yanny-initialize-original-mix",
-  "title": "Initialize (Original Mix)",
-  "artist": "The Paragod & DJ Yanny",
-  "tags": ["hard trance", "1997", "Germany", "Fog Area Records", "classic hard trance"],
-  "description": "“Initialize” is a high-energy hard trance anthem by The Paragod & DJ Yanny, originally released in 1997 via Fog Area Records in Germany. Known for its aggressive synth stabs, pounding 4/4 rhythm, and rave-era vocal samples, it became a defining track of late-'90s German hard trance. A remastered version was reissued by EDM Records in 2014, preserving its underground legacy.",
-  "releaseYear": 1997,
-  "label": "Fog Area Records / EDM Records",
-  "album": null,
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Hard Trance",
-  "aliases": ["The Paragod", "DJ Yanny"],
-  "chartInfo": { "German Club Charts": "#12 (1997, DDC regional hard trance ranking)" },
-  "synths": ["acid stabs", "filtered leads", "pitch-rising motifs"],
-  "drums": ["4/4 kick", "snappy snares", "shuffling hi-hats"],
-  "influences": ["German hard trance", "Fog Area sound", "late '90s club culture"],
-  "genre": "Electronic",
-  "subgenre": "Hard Trance",
-  "youtube": ["https://www.youtube.com/watch?v=vTBwyjJ1MLw"]
-   },
-   {
-  "id": "kai-tracid-destinys-path-energy-mix",
-  "title": "Destiny’s Path (Energy Mix)",
-  "artist": "Kai Tracid",
-  "tags": ["trance", "1999", "Germany", "Tracid Traxxx", "Energy Mix"],
-  "description": "“Destiny’s Path (Energy Mix)” by German producer Kai Tracid, released in 1999 on the album *Trance & Acid*. The hard‑hitting mix features acid-tinged arpeggios, dramatic breakdowns, and a pulsing trance groove. It became one of Tracid’s early charting singles and helped define his acid‑trance signature sound.",
-  "releaseYear": 1999,
-  "label": "Tracid Traxxx",
-  "album": "Trance & Acid",
-  "country": "Germany",
-  "artistBorn": "1972‑01‑17 (Kai Franz)",
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Kai Tracid", "Kai Mac Donald"],
-  "chartInfo": { "Germany": "#29 (1999, Official Singles Chart)" },
-  "synths": ["acid trance arp", "atmospheric pads", "shimmering leads"],
-  "drums": ["steady 4/4 kick", "claps/snare on 2‑4", "driving hi‑hats"],
-  "influences": ["German acid trance", "late‑90s melodic trance", "Tracid’s acid‑trance style"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=NA4CtzoOBHQ"]
-   },
-   {
-  "id": "york-on-the-beach-original",
-  "title": "On the Beach (Original Mix)",
-  "artist": "York",
-  "tags": ["trance", "1999", "Germany", "Manifesto / Planet Love Records", "CRW Edit"],
-  "description": "“On the Beach” by German duo York (Torsten & Jörg Stenzel), released in 1999 and licensed in the UK in 2000. Built around a sample from Chris Rea’s original, the track blends Balearic guitar hooks with trance rhythms and lush pads. The CRW Edit became the mainstream hit version, earning wide chart success and extensive compilation inclusion.",
-  "releaseYear": 1999,
-  "label": "Planet Love Records (GER), licensed to Manifesto (UK)",
-  "album": "On the Beach",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["York"],
-  "chartInfo": { "UK Singles Chart": "#4 (June 2000); UK Dance Chart #1 (10 June 2000)" },
-  "synths": ["Balearic guitar hooks", "lush pads", "plucked lead arpeggios"],
-  "drums": ["steady 4/4 kick", "snare/clap on 2‑4", "shimmering hi‑hats"],
-  "influences": ["Chris Rea sample adaptation", "German melodic trance", "Balearic house influence"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=bdx1fPIevN0"]
-   },
-   {
-  "id": "davie-forbes-sequential-original",
-  "title": "Sequential (Acid Trance 1998)",
-  "artist": "Davie Forbes",
-  "tags": ["acid trance", "1998", "UK", "Uprising Trance Records", "hard trance"],
-  "description": "“Sequential” is a driving acid‑trance track by UK producer Davie Forbes, released in 1998 on Uprising Trance Records (catalog UPRIS T 8). Combining rolling 303 basslines, hard-hitting rhythms, and euphoric trance motifs, it captures the sound of late‑90s acid-infused trance.",
-  "releaseYear": 1998,
-  "label": "Uprising Trance Records",
-  "album": "Octave Kitten / Sequential",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Davie Forbes", "David Forbes"],
-  "chartInfo": { "UK Club Charts": "Top 15 in regional UK hard trance rotation (1998)" },
-  "synths": ["acid‑style 303 bassline", "atmospheric trance pads", "arpeggiated lead loops"],
-  "drums": ["steady 4/4 kick", "accented snares/claps", "rolling hi‑hats"],
-  "influences": ["UK hard‑trance", "acid trance aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=NfpR3mrnQ6A"]
-   },
-   {
-  "id": "emmanuel-top-acid-phase-kai-tracid-remix",
-  "title": "Acid Phase (Kai Tracid Remix)",
-  "artist": "Emmanuel Top",
-  "tags": ["acid trance", "1994‑2002", "France/Germany", "Attack Records / Kosmo Records", "Kai Tracid Remix"],
-  "description": "Kai Tracid’s remix of Emmanuel Top’s acid‑classic “Acid Phase” delivers pulsing 303 patterns and euphoric trance energy. Originally released in 1994 on Attack Records and later reissued in 2002 on Kosmo Records, the remix runs approximately 6:37 and showcases a fusion of acid techno grit with melodic trance flair.",
-  "releaseYear": 1994,
-  "label": "Attack Records (orig), Kosmo Records (2002 Remix)",
-  "album": "Acid Phase Remixes",
-  "country": "France / Germany",
-  "artistBorn": "1971‑10‑30 (Emmanuel Top)",
-  "artistPrimaryGenre": "Acid Trance",
-  "aliases": ["Emmanuel Top", "E. Top"],
-  "chartInfo": null,
-  "synths": ["acid 303 bassline", "resonant filter stabs", "trance-style pads"],
-  "drums": ["steady 4/4 kick", "punchy claps/snare", "bright hi‑hats"],
-  "influences": ["acid techno", "German trance remix aesthetic", "90s rave culture"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=XxVDyElrnGk"]
-   },
-   {
-  "id": "the-blue-piano-blue-ballad-piano-version",
-  "title": "Blue Ballad (Piano Version)",
-  "artist": "The Blue Piano",
-  "tags": ["hard trance", "1996", "UK", "Uprising Trance Records", "Piano Version"],
-  "description": "“Blue Ballad (Piano Version)” is a piano‑oriented reinterpretation of The Blue Piano’s hard‑trance track from 1996, released on Uprising Trance Records (catalog UPRIS T 8). At about 4:24 in duration, the piano version strips away the harder elements in favor of a melodic piano rendition retaining trance‑infused chord progressions.",
-  "releaseYear": 1996,
-  "label": "Uprising Trance Records",
-  "album": "Octave Kitten / Blue Ballad",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["The Blue Piano"],
-  "chartInfo": { "UK Club Chart": "Top 20 rotation in acid trance sets (1996)" },
-  "synths": ["piano-driven melody", "trance chord voicings"],
-  "drums": ["omitted (piano‑only version)"],
-  "influences": ["UK acid trance", "hard trance melodic reinterpretations"],
-  "genre": "Electronic",
-  "subgenre": "Trance / Piano Version",
-  "youtube": ["https://www.youtube.com/watch?v=NfpR3mrnQ6A"]
-   },
-   {
-  "id": "leroy-the-first-flight-original",
-  "title": "The First Flight",
-  "artist": "Leroy",
-  "tags": ["trance", "1993", "Italy", "DJ Leroy", "classic trance"],
-  "description": "“The First Flight” is a trance single by DJ Leroy, released in 1993 on vinyl in Italy. Known for its melodic trance progression, driving beat, and atmospheric energy, it remains a cult favorite in classic trance circles and is featured in regional club playlists.",
-  "releaseYear": 1993,
-  "label": "DJ Leroy (self‑released)",  
-  "album": "The First Flight – Single",
-  "country": "Italy",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["DJ Leroy", "Leroy"],
-  "chartInfo": { "Italian Dance Circle Rotation": "Top 20 in regional Italian club charts (1993)" },
-  "synths": ["uplifting trance lead", "ambient pads", "arpeggiated motifs"],
-  "drums": ["steady 4/4 kick", "clap/snare on 2‑4", "sparse hi‑hats"],
-  "influences": ["early 90s trance", "Italian trance singles", "club-focused trance production"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": []
-   },
-   {
-  "id": "alien-factory-scraper-original",
-  "title": "Scraper (Original Mix)",
-  "artist": "Alien Factory",
-  "tags": ["acid trance", "1998", "Germany", "Time Unlimited", "hard trance"],
-  "description": "“Scraper (Original Mix)” by Berlin-based duo Alien Factory (Frank Möbus & co.), released in 1998 on Time Unlimited. Known as an intense club opener, it features driving acid‑style 303 riffs, rolling rhythms, and a relentless groove—often used in trance events such as Helter Skelter’s ‘Outer Limits’.",
-  "releaseYear": 1998,
-  "label": "Time Unlimited",
-  "album": "Scraper (12\" single)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Alien Factory"],
-  "chartInfo": { "German Club Rotation": "Top 10 in Time Unlimited club sets (1998)" },
-  "synths": ["acid‑style 303 basslines", "staccato synth stabs", "euphoric trance motifs"],
-  "drums": ["steady 4/4 kick", "snare/clap on 2‑4", "rolling hi‑hats"],
-  "influences": ["German hard trance", "acid‑infused trance aesthetic"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=tsQ1KurubqQ"]  
-   },
-   {
-  "id": "instant-zen-love-dove-original",
-  "title": "Love Dove",
-  "artist": "Instant Zen",
-  "tags": ["acid trance", "hard trance", "1994", "Germany", "Noom Records", "Fjord EP"],
-  "description": "“Love Dove” is a powerful acid‑trance/hard‑trance track released in 1994 by Instant Zen on the *Fjord EP* (Noom Records, Germany). Clocking in at approximately 5:43, it features rolling 303 basslines, shimmering trance pads, and a driving beat—typical of mid‑90s German acid trance sound.",
-  "releaseYear": 1994,
-  "label": "Noom Records",
-  "album": "Fjord EP",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Instant Zen"],
-  "chartInfo": { "Germany Acid/Hard Rotation": "Top 15 in German club rotation (1994)" },
-  "synths": ["acid 303 bassline", "airy trance pads", "repeating lead loop"],
-  "drums": ["steady 4/4 kick", "snappy claps", "rolling hi‑hats"],
-  "influences": ["German acid trance", "hard trance aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=lOxqzOiVuYc"]
-   },
-   {
-  "id": "usura-trance-emotions-white-label-mix",
-  "title": "Trance Emotions (White Label Mix)",
-  "artist": "U.S.U.R.A.",
-  "tags": ["trance", "1998", "Italy", "Time Records", "White Label Mix"],
-  "description": "“Trance Emotions (White Label Mix)” is a stripped-down, club-oriented version of U.S.U.R.A.’s 1998 trance single, featured on the *Trance Emotions* EP released by Time Records. At approximately 4:33, the mix emphasizes raw trance energy with recurring vocal hooks and a focused beat, tailored for DJ play and underground sets.",
-  "releaseYear": 1998,
-  "label": "Time Records / T30",
-  "album": "Trance Emotions EP",
-  "country": "Italy",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["U.S.U.R.A."],
-  "chartInfo": { "European Club Rotation": "Top 20 in Italian/Euro club playlists (1998)" },
-  "synths": ["repetitive trance lead", "vocal hook samples", "energetic pads"],
-  "drums": ["4/4 kick", "snappy claps", "steady hi‑hats"],
-  "influences": ["Euro‑trance style", "DJ Quicksilver edits", "late‑90s Italian trance"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=USlKWB8u3nw"]
-   },
-   {
-  "id": "art-of-trance-gloria-transparent-mix",
-  "title": "Gloria (Transparent Mix)",
-  "artist": "Art Of Trance",
-  "tags": ["progressive trance", "1993", "UK", "Platipus Records", "Transparent Mix"],
-  "description": "“Gloria (Transparent Mix)” by Art Of Trance (Simon Berry) was originally released in 1993 on Platipus Records in the UK. This nearly 8‑minute version is famed for its shimmering piano motifs, melancholic ambient breakdown, and trance‑driven momentum. Widely regarded as one of the hallmark underground trance tracks of the early 1990s.",
-  "releaseYear": 1993,
-  "label": "Platipus Records",
-  "album": "Gloria (12\" maxi single)",
-  "country": "UK",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Art Of Trance"],
-  "chartInfo": null,
-  "synths": ["shimmering piano melody", "ethereal pads", "subtle arpeggiated motifs"],
-  "drums": ["steady 4/4 kick", "light claps", "soft hi‑hats"],
-  "influences": ["UK progressive trance", "early Platipus aesthetic"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=EZ3vZ6lrdug"]
-   },
-   {
-  "id": "polyphonic-mamy-trip-mix",
-  "title": "Mamy (T.R.I.P. Mix)",
-  "artist": "Polyphonic",
-  "tags": ["trance", "1996", "Italy/Belgium", "Do It Yourself Entertainment", "T.R.I.P. Mix"],
-  "description": "“Mamy (T.R.I.P. Mix)” is a hypnotic trance remix by Polyphonic, released circa 1996 on the *Mamy* EP (Do It Yourself Entertainment, Italy). Clocking around 4:44, it layers pulsating trance rhythms, subtle ambient pads, and looping melodic motifs to create a deeper, more immersive experience than the original.",
-  "releaseYear": 1996,
-  "label": "Do It Yourself Entertainment",
-  "album": "Mamy EP",
-  "country": "Italy/Belgium",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Polyphonic"],
-  "chartInfo": { "European Club Rotation": "Top 20 in regional trance playlists (1996)" },
-  "synths": ["arpeggiated trance leads", "ambient pads", "subtle sequenced motifs"],
-  "drums": ["steady 4/4 kick", "snare on 2‑4", "rolling hi‑hats"],
-  "influences": ["mid‑90s Euro trance", "deep remix aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Trance",
-  "youtube": ["https://www.youtube.com/watch?v=-XLx9fBJ0jg"]
-   },
-   {
-  "id": "amorph-parazyt-original",
-  "title": "Parazyt",
-  "artist": "Amorph",
-  "tags": ["acid trance", "hard trance", "1994", "Germany", "Formaldehyd Records"],
-  "description": "“Parazyt” by Amorph (Formaldehyd Records, Germany) — a 1994 hard‑trance staple featuring spiraling 303 acid riffs, dense atmospheres, and relentless energy. Clocking at approximately 7:47, the track is widely cited as a classic of early German acid‑trance and remains a favorite in retrospective sets.",
-  "releaseYear": 1994,
-  "label": "Formaldehyd Records",
-  "album": "Parazyt (12\" single)",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["Amorph"],
-  "chartInfo": { "Club Rotation": "Frequent Top 10 pick in Germany hard‑trance sets (1994)" },
-  "synths": ["acid 303 basslines", "atmospheric trance pads", "gritty synth stabs"],
-  "drums": ["steady 4/4 kick", "punchy claps/snare", "rolling hi‑hats"],
-  "influences": ["Formaldehyd Records acid trance style", "German hard trance tradition"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=sg9KohNAYIQ"]
-   },
-   {
-  "id": "repulsor-sentimental-circuit-original",
-  "title": "Sentimental Circuit",
-  "artist": "Repulsor (as featured on Acid Flash Vol. 4)",
-  "tags": ["acid trance", "1996", "Germany", "Acid Flash compilation", "Repulsor"],
-  "description": "“Sentimental Circuit” is a standout acid‑trance track featured on the “Acid Flash Vol. 4” compilation (Germany, 1996). Produced by Samuel Malm under the alias Repulsor, it showcases squelching TB‑303 acid lines, hypnotic sequences, and driving trance percussion—reflecting mid‑90s German acid‑trance club culture.",
-  "releaseYear": 1996,
-  "label": "Acid Flash (SPV/Time Records compilation)",
-  "album": "Acid Flash Vol. 4",
-  "country": "Germany",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Acid Trance",
-  "aliases": ["Repulsor"],
-  "chartInfo": { "German Acid‑Trance Club Rotation": "Reached Top 10 on Acid Flash club sets (1996)" },
-  "synths": ["acid 303 sequencer riffs", "filtered squelch bass", "pt‑filter sweeps"],
-  "drums": ["steady 4/4 kick", "snappy claps", "rolling hi‑hats"],
-  "influences": ["German acid trance", "Acid Flash compilation aesthetic", "mid‑90s trance club sets"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=W7QaeTDoDko"]
-   },
-   {
-  "id": "feec lichette-flying-sausage-pandanlagueule-mix",
-  "title": "Flying Sausage (Pandanlagueule Mix)",
-  "artist": "Fée Clochette",
-  "tags": ["acid trance", "1996", "France", "Trancemaster / Tralala EP", "Pandanlagueule Mix"],
-  "description": "“Flying Sausage (Pandanlagueule Mix)” is a quirky acid‑trance track by French artist Fée Clochette. Released in 1996, it appears on the *Tralala EP* and *Trancemaster 12: Return to Goa* compilation. With playful 303 riffs, quirky melodic samples, and trance‑driven beats, the Pandanlagueule Mix leans into whimsical acid minimalist style.",
-  "releaseYear": 1996,
-  "label": "Tralala EP (DIY), featured on Trancemaster 12 (Return to Goa)",
-  "album": "Tralala EP / Trancemaster 12 comp.",
-  "country": "France",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Acid Trance",
-  "aliases": ["Fée Clochette", "Fee Clochette"],
-  "chartInfo": { "Underground Acid Sets": "Top 15 pick in European acid‑trance rotations (1996)" },
-  "synths": ["acid 303 bassline", "quirky melodic FX", "filtered stabs"],
-  "drums": ["steady 4/4 kick", "snappy clap", "loopy hi‑hats"],
-  "influences": ["French acid‑trance", "quirky minimal acid ideas", "Goa‑style comp aesthetics"],
-  "genre": "Electronic",
-  "subgenre": "Acid Trance",
-  "youtube": ["https://www.youtube.com/watch?v=12Yh92geZlU"]
-   },
-   {
-  "id": "bbe-seven-days-and-one-week-club-mix",
-  "title": "Seven Days and One Week (Club Mix)",
-  "artist": "B.B.E.",
-  "tags": ["dream trance", "1996", "Italy/France", "Triangle Records", "Club Mix"],
-  "description": "The Club Mix of “Seven Days and One Week” by B.B.E. (Bruno Sanchioni, Emmanuel Top & Bruno Quartier), released in 1996. This extended version (~8:28) amplifies the hit’s iconic piano stabs, rolling trance groove, and euphoric energy tailored for club dancefloors.",
-  "releaseYear": 1996,
-  "label": "Triangle Records",
-  "album": "Seven Days & One Week – Single",
-  "country": "Italy / France",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Trance",
-  "aliases": ["B.B.E."],
-  "chartInfo": { "Germany/UK/Spain Top‑10": "Peaked top‑10 in Germany, UK, Spain (1996)" },
-  "synths": ["piano stabs", "rolling arpeggios", "anthemic synth pads"],
-  "drums": ["steady 4/4 kick", "snappy claps", "driving hi‑hats"],
-  "influences": ["dream trance", "Balearic piano trance", "euphoric mid‑90s trance"],
-  "genre": "Electronic",
-  "subgenre": "Dream Trance",
-  "youtube": ["https://www.youtube.com/watch?v=3wA6M_qTG_w"]
-   },
-   {
-  "id": "lords-of-acid-undress-and-possess-original",
-  "title": "Undress and Possess",
-  "artist": "Lords of Acid",
-  "tags": ["acid house", "industrial dance", "1994", "Belgium/USA", "Lust album", "provocative club"],
-  "description": "“Undress and Possess” is a flagship single from Lords of Acid’s 1994 album *Lust*. Crafted by Praga Khan and Oliver Adams, the track fuses acid-house grooves with industrial dance energy, laced with risqué vocals and tongue-in-cheek lyrics. With its pulsating synth riffs, commanding 4/4 beat, and offbeat sexual satire, it became a staple in clubs and remains one of the band’s most iconic tracks—known for pushing boundaries, entertaining with shock value, and encapsulating the group’s provocative aesthetic.",
-  "releaseYear": 1994,
-  "label": "Antler-Subway / Never Records",
-  "album": "Lust",
-  "country": "Belgium/USA",
-  "artistBorn": null,
-  "artistPrimaryGenre": "Industrial/Electronic",
-  "aliases": ["Lords of Acid"],
-  "chartInfo": { "UK/Belgian Dance Charts": "Top 20 dance rotation, cult club staple (1994)" },
-  "synths": ["acid bassline", "squelchy 303 riffs", "industrial synth stab"],
-  "drums": ["steady 4/4 kick", "snappy claps", "hi-hat patterns"],
-  "influences": ["acid house", "Industrial dance", "provocative club culture"],
-  "genre": "Electronic",
-  "subgenre": "Acid House / Industrial Dance",
-  "youtube": ["https://www.youtube.com/watch?v=M8FmuDf-KI4"]
-   }
-
+  {
+    "id": "mega-city-2-darker-side-of-evil",
+    "title": "Darker Side Of Evil",
+    "artist": "Mega City 2",
+    "tags": [
+      "hardcore",
+      "1994",
+      "UK",
+      "Industrial Strength Records",
+      "hardcore techno"
+    ],
+    "description": "A dark and intense hardcore techno track released in 1994 by Mega City 2 on Industrial Strength Records. Known for its heavy beats and ominous atmosphere, it’s a classic of the hardcore techno genre.",
+    "releaseYear": 1994,
+    "label": "Industrial Strength Records",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hardcore",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "dark synth pads",
+      "industrial basslines"
+    ],
+    "drums": [
+      "hard 4/4 kick",
+      "aggressive percussion"
+    ],
+    "influences": [
+      "early hardcore techno",
+      "industrial music",
+      "90s rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hardcore",
+      "Hardcore Techno"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=KxfLft7zyvg"
+    ]
+  },
+  {
+    "id": "dj-ham-jump-2-da-groove",
+    "title": "Jump 2 Da Groove",
+    "artist": "DJ Ham",
+    "tags": [
+      "hardcore",
+      "2005",
+      "UK",
+      "Blatant Beats",
+      "happy hardcore"
+    ],
+    "description": "A high-energy happy hardcore track by DJ Ham, released in 2005 on Blatant Beats. Known for its uplifting melodies and fast-paced beats, it captures the essence of mid-2000s UK rave culture.",
+    "releaseYear": 2005,
+    "label": "Blatant Beats",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hardcore",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "synth leads",
+      "rave stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "UK rave culture",
+      "happy hardcore",
+      "breakbeat hardcore"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hardcore",
+      "Happy Hardcore"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=gp9EpfRs1Yw"
+    ]
+  },
+  {
+    "id": "analoge-dynamix-a-syd-again-1994",
+    "title": "A-syd Again",
+    "artist": "Analoge Dynamix",
+    "tags": [
+      "techno",
+      "1994",
+      "UK",
+      "Industrial Strength Records",
+      "hardcore techno"
+    ],
+    "description": "A raw and energetic techno track from 1994 by Analoge Dynamix, released on Industrial Strength Records. Known for its driving beats and intense synths, it’s a staple of early hardcore techno.",
+    "releaseYear": 1994,
+    "label": "Industrial Strength Records",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Techno",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "acid synth lines",
+      "dark synth pads"
+    ],
+    "drums": [
+      "hard 4/4 kick",
+      "snappy snares",
+      "metallic percussion"
+    ],
+    "influences": [
+      "early hardcore techno",
+      "industrial",
+      "90s rave scene"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Techno",
+      "Hardcore Techno"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=U9jFi9GF1TY"
+    ]
+  },
+  {
+    "id": "liquid-sweet-harmony",
+    "title": "Sweet Harmony",
+    "artist": "Liquid",
+    "tags": [
+      "hardcore",
+      "1992",
+      "UK",
+      "XL Recordings",
+      "breakbeat hardcore",
+      "rave"
+    ],
+    "description": "“Sweet Harmony” by Liquid is an iconic 1992 breakbeat hardcore anthem that helped define the early UK rave scene. The track masterfully blends euphoric piano melodies with energetic breakbeats and lush vocal samples, creating a euphoric atmosphere that resonated across clubs and raves worldwide. Built around a catchy piano riff and soulful vocal snippets, it captures the emotional intensity and optimism that characterized early 90s rave culture. It was a pivotal release that bridged hardcore with more melodic and accessible sounds, influencing countless producers and continuing to be a beloved classic in electronic music history.",
+    "releaseYear": 1992,
+    "label": "XL Recordings",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat Hardcore",
+    "aliases": [],
+    "chartInfo": {
+      "UK Singles Chart": 15
+    },
+    "synths": [
+      "piano riffs",
+      "lush pads",
+      "vocal samples"
+    ],
+    "drums": [
+      "breakbeat loops",
+      "snappy snares",
+      "4/4 kick"
+    ],
+    "influences": [
+      "early rave culture",
+      "breakbeat hardcore",
+      "acid house"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Breakbeat Hardcore",
+      "Rave"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=9YvX8hnkg8I"
+    ]
+  },
+  {
+    "id": "dr-base-original-oyster-hard-trance-1997",
+    "title": "Original Oyster",
+    "artist": "D.R. Base",
+    "tags": [
+      "hard trance",
+      "1997",
+      "Netherlands",
+      "Basic Beat Recordings",
+      "trance"
+    ],
+    "description": "“Original Oyster” by D.R. Base is a quintessential hard trance track from 1997, released on Basic Beat Recordings. Featuring driving, hypnotic synth arpeggios and powerful, pulsating beats, the track captures the energy and intensity of late 90s European trance. With its layered melodic motifs and hard-hitting rhythm section, it remains a classic in the hard trance scene and a favorite among DJs and trance enthusiasts.",
+    "releaseYear": 1997,
+    "label": "Basic Beat Recordings",
+    "album": null,
+    "country": "Netherlands",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "hypnotic synth arpeggios",
+      "layered melodic motifs"
+    ],
+    "drums": [
+      "pulsating kicks",
+      "driving percussion"
+    ],
+    "influences": [
+      "late 90s trance",
+      "European club scene"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    ]
+  },
+  {
+    "id": "lemon8-bells-of-revolution-steve-thomas-remix",
+    "title": "Bells of Revolution (Steve Thomas Remix)",
+    "artist": "Lemon8",
+    "tags": [
+      "hard trance",
+      "1997",
+      "UK",
+      "Tidy Trax",
+      "neo rave"
+    ],
+    "description": "A defining hard trance anthem from 1997, 'Bells of Revolution' by Lemon8, remixed by Steve Thomas, encapsulates the euphoric and driving essence of late 90s UK rave culture. Released on Tidy Trax, the track features uplifting melodies, rolling basslines, and energetic synths, making it a staple in hard dance sets and a favorite among enthusiasts of the genre.",
+    "releaseYear": 1997,
+    "label": "Tidy Trax",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard Trance",
+    "aliases": [],
+    "chartInfo": {
+      "UK Singles Chart": 76
+    },
+    "synths": [
+      "uplifting melodies",
+      "energetic synths"
+    ],
+    "drums": [
+      "rolling basslines",
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "UK rave culture",
+      "hard trance",
+      "neo rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hard Trance",
+      "Neo Rave"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=ogmidR2HEEo"
+    ]
+  },
+  {
+    "id": "amorph-astronaut-hard-trance-1994",
+    "title": "Astronaut",
+    "artist": "Amorph",
+    "tags": [
+      "hard trance",
+      "1994",
+      "Germany",
+      "Forbidden Planet Records",
+      "trance"
+    ],
+    "description": "“Astronaut” by Amorph is a classic hard trance track released in 1994 on Forbidden Planet Records. Featuring driving beats, soaring synth leads, and hypnotic melodies, this track captures the essence of early European trance music and remains a favorite among trance enthusiasts for its atmospheric depth and dancefloor energy.",
+    "releaseYear": 1994,
+    "label": "Forbidden Planet Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "soaring synth leads",
+      "hypnotic melodies"
+    ],
+    "drums": [
+      "driving beats",
+      "steady kick"
+    ],
+    "influences": [
+      "early trance",
+      "European club scene",
+      "90s rave culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=04_GOwn0Bpg"
+    ]
+  },
+  {
+    "id": "atb-dont-stop-bassliner-mix",
+    "title": "Don't Stop! (Bassliner Mix)",
+    "artist": "ATB",
+    "tags": [
+      "trance",
+      "1999",
+      "Germany",
+      "Kontor Records",
+      "vocal trance"
+    ],
+    "description": "The 'Bassliner Mix' of 'Don't Stop!' by ATB offers a deeper, bass-driven interpretation of the original track. Released in 1999, this version emphasizes the rhythmic elements and provides a more underground feel while retaining the uplifting melodies that made the original a hit. It's a testament to ATB's versatility in producing different flavors of trance music.",
+    "releaseYear": 1999,
+    "label": "Kontor Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": "1973-02-26",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "André Tanneberger"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": 86,
+      "UK Dance Singles Chart": 32,
+      "UK Independent Singles Chart": 19
+    },
+    "synths": [
+      "deep basslines",
+      "uplifting melodies"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "late 90s trance",
+      "eurodance",
+      "vocal trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Trance",
+      "Vocal Trance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=ogmidR2HEEo"
+    ]
+  },
+  {
+    "id": "macrocosm-amplifier-hard-trance-1995",
+    "title": "Amplifier",
+    "artist": "Macrocosm",
+    "tags": [
+      "hard trance",
+      "1995",
+      "Germany",
+      "G.A.R. Records",
+      "trance"
+    ],
+    "description": "Released in 1995 on G.A.R. Records, 'Amplifier' by Macrocosm is a quintessential hard trance track that encapsulates the raw energy and driving rhythms characteristic of mid-90s European trance. The track features pulsating basslines, hypnotic synths, and a relentless 4/4 kick, making it a staple in the hard trance scene and a favorite among DJs and enthusiasts alike.",
+    "releaseYear": 1995,
+    "label": "G.A.R. Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "hypnotic synths",
+      "acid stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "early hard trance",
+      "90s rave culture",
+      "European club scene"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=wAxHTwQ8GGI"
+    ]
+  },
+  {
+    "id": "warp-brothers-vs-aquagen-phatt-bass-aquagen-short-mix",
+    "title": "Phatt Bass (Aquagen Short Mix)",
+    "artist": "Warp Brothers vs. Aquagen",
+    "tags": [
+      "hard trance",
+      "2000",
+      "Germany",
+      "Dos Or Die Records",
+      "trance"
+    ],
+    "description": "The 'Aquagen Short Mix' of 'Phatt Bass' by Warp Brothers vs. Aquagen delivers a high-energy, bass-driven hard trance experience. Released in 2000 on Dos Or Die Records, this track showcases the synergy between the German electronic duos, blending pulsating basslines with dynamic synths, making it a staple in early 2000s rave culture.",
+    "releaseYear": 2000,
+    "label": "Dos Or Die Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard Trance",
+    "aliases": [],
+    "chartInfo": {
+      "UK Dance Singles Chart": 9
+    },
+    "synths": [
+      "dynamic synths",
+      "bass-driven leads"
+    ],
+    "drums": [
+      "pulsating basslines",
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "early 2000s rave culture",
+      "hard trance",
+      "German electronic scene"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=VPV78f9ptpo"
+    ]
+  },
+  {
+    "id": "a-man-possessed-black-white-knuckleheadz-remix",
+    "title": "Black & White (Knuckleheadz Remix)",
+    "artist": "A Man Possessed",
+    "tags": [
+      "hard trance",
+      "2001",
+      "UK",
+      "Dos Or Die Records",
+      "trance"
+    ],
+    "description": "The 'Knuckleheadz Remix' of 'Black & White' by A Man Possessed delivers a high-energy, bass-driven hard trance experience. Released in 2001 on Dos Or Die Records, this track showcases the synergy between the UK electronic duo and the remixing prowess of Knuckleheadz, blending pulsating basslines with dynamic synths, making it a staple in early 2000s rave culture.",
+    "releaseYear": 2001,
+    "label": "Dos Or Die Records",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard Trance",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "dynamic synths",
+      "bass-driven leads"
+    ],
+    "drums": [
+      "pulsating basslines",
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "early 2000s rave culture",
+      "hard trance",
+      "UK electronic scene"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=CMePEJ4ghdw"
+    ]
+  },
+  {
+    "id": "phlash-get-a-life-frantic-theme",
+    "title": "Get A Life (Frantic Theme)",
+    "artist": "Phlash! feat. Steve Hill",
+    "tags": [
+      "hard house",
+      "2002",
+      "UK",
+      "Tripoli Trax",
+      "trance"
+    ],
+    "description": "Released in August 2002 on Tripoli Trax, 'Get A Life (Frantic Theme)' by Phlash! featuring Steve Hill is a quintessential hard house track that encapsulates the raw energy and driving rhythms characteristic of early 2000s UK hard house. The track features a cheery piano melody and a vocal sample that may be meant ironically, making it a staple in the hard house scene and a favorite among DJs and enthusiasts alike.",
+    "releaseYear": 2002,
+    "label": "Tripoli Trax",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [],
+    "chartInfo": {
+      "UK Singles Chart": 79,
+      "UK Dance Singles Chart": 22,
+      "UK Independent Singles Chart": 12
+    },
+    "synths": [
+      "cheery piano melody",
+      "synth stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "early 2000s UK hard house",
+      "Frantic club events",
+      "UK rave culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=jh6kkMnp5Kc"
+    ]
+  },
+  {
+    "id": "joe-hunt-up-to-no-good",
+    "title": "Up To No Good",
+    "artist": "Joe Hunt",
+    "tags": [
+      "bassline house",
+      "2024",
+      "UK",
+      "Room Two Recordings",
+      "club anthem"
+    ],
+    "description": "Released on August 2, 2024, 'Up To No Good' by Joe Hunt is a high-energy bassline house track that quickly gained traction in the UK club scene. With its infectious bassline and catchy hooks, the track showcases Joe Hunt's signature style, blending elements of UK garage and house. The single charted at #8 on the UK Singles Chart and #7 on the UK Singles Downloads Chart, reflecting its widespread popularity and DJ support.",
+    "releaseYear": 2024,
+    "label": "Room Two Recordings",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Bassline House",
+    "aliases": [],
+    "chartInfo": {
+      "UK Singles Chart": 8,
+      "UK Singles Downloads Chart": 7
+    },
+    "synths": [
+      "pulsating basslines",
+      "synth stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "UK garage",
+      "bassline house",
+      "club anthems"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Bassline House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=loGTPHM9DPw"
+    ]
+  },
+  {
+    "id": "ian-m-annihilation",
+    "title": "Annihilation",
+    "artist": "Ian M",
+    "tags": [
+      "hard house",
+      "1998",
+      "UK",
+      "Trade Records",
+      "trance"
+    ],
+    "description": "Released in 1998 on Trade Records, 'Annihilation' by Ian M is a quintessential hard house track that encapsulates the raw energy and driving rhythms characteristic of late 90s UK hard house. The track features pulsating basslines, hypnotic synths, and a relentless 4/4 kick, making it a staple in the hard house scene and a favorite among DJs and enthusiasts alike.",
+    "releaseYear": 1998,
+    "label": "Trade Records",
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [],
+    "chartInfo": null,
+    "synths": [
+      "hypnotic synths",
+      "acid stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "late 90s hard house",
+      "UK rave culture",
+      "Trade club nights"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=EHIdtWb_4LQ"
+    ]
+  },
+  {
+    "id": "ador-young-world-smokey-bubblin-b-remix",
+    "title": "Young World (Smokey Bubblin' B Remix)",
+    "artist": "A.D.O.R.",
+    "tags": [
+      "UK Garage",
+      "2023",
+      "Weapons Records",
+      "Smokey Bubblin' B",
+      "bassline"
+    ],
+    "description": "Released on September 22, 2023, 'Young World (Smokey Bubblin' B Remix)' by A.D.O.R. is a high-energy UK Garage track that reimagines the original with a fresh, bassline-driven approach. Smokey Bubblin' B's remix brings a dynamic rhythm and infectious groove, making it a standout in the garage scene. The track has been well-received by DJs and listeners alike, charting in multiple DJ charts and playlists.",
+    "releaseYear": 2023,
+    "label": "Weapons Records",
+    "album": null,
+    "country": "USA",
+    "artistBorn": "1969-09-26",
+    "artistPrimaryGenre": "Hip Hop",
+    "aliases": [
+      "Eddie Castellanos"
+    ],
+    "chartInfo": {
+      "Traxsource": {
+        "chartPosition": 3,
+        "date": "2023-09-28"
+      },
+      "Beatport": {
+        "chartPosition": 15,
+        "date": "2023-11-30"
+      }
+    },
+    "synths": [
+      "deep basslines",
+      "synth stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "UK Garage",
+      "Bassline",
+      "Hip Hop"
+    ],
+    "genre": "Electronic",
+    "subgenre": "UK Garage",
+    "youtube": [
+      "https://www.youtube.com/watch?v=rxJVdPrQRMA"
+    ]
+  },
+  {
+    "id": "art-of-trance-madagascar-ferry-corsten-remix",
+    "title": "Madagascar (Ferry Corsten Remix)",
+    "artist": "Art Of Trance",
+    "tags": [
+      "trance",
+      "1999",
+      "UK",
+      "Platipus Records",
+      "progressive trance"
+    ],
+    "description": "Released in 1999 on Platipus Records, 'Madagascar (Ferry Corsten Remix)' by Art Of Trance is a seminal track in the progressive trance genre. The remix by Ferry Corsten brought a fresh, energetic vibe to the original, featuring uplifting melodies, driving basslines, and intricate synth work. This track became a staple in the trance community and is considered a classic in the genre.",
+    "releaseYear": 1999,
+    "label": "Platipus Records",
+    "album": null,
+    "country": "UK",
+    "artistBorn": "1973-12-04",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Art Of Trance",
+      "Simon Berry"
+    ],
+    "chartInfo": {
+      "UK Dance Singles Chart": 1
+    },
+    "synths": [
+      "uplifting melodies",
+      "driving basslines",
+      "intricate synth work"
+    ],
+    "drums": [
+      "4/4 kick",
+      "claps",
+      "hi-hats"
+    ],
+    "influences": [
+      "progressive trance",
+      "UK rave culture",
+      "Platipus Records sound"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=YipIMl3xpHg"
+    ]
+  },
+  {
+    "id": "nostrum-polaris",
+    "title": "Polaris",
+    "artist": "Nostrum",
+    "tags": [
+      "hard trance",
+      "1995",
+      "Germany",
+      "Time Unlimited",
+      "acid trance"
+    ],
+    "description": "Released in 1995 on Time Unlimited, 'Polaris' by Nostrum (aka Bernd Augustinski) is a powerful and emotionally intense hard trance anthem. It combines high-BPM energy with shimmering arpeggios and acidic sequences, creating a euphoric, melancholic sound that became a staple in 90s underground trance scenes across Europe.",
+    "releaseYear": 1995,
+    "label": "Time Unlimited",
+    "album": "Nostrum EP 4",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid arpeggios",
+      "melancholic pads",
+      "resonant lead synths"
+    ],
+    "drums": [
+      "fast 4/4 kick",
+      "rolling snares",
+      "open hi-hats"
+    ],
+    "influences": [
+      "acid trance",
+      "early techno",
+      "emotional rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=D-gfTkk8Yj8"
+    ]
+  },
+  {
+    "id": "nostrum-blow-back-original",
+    "title": "Blow Back (Original)",
+    "artist": "Nostrum",
+    "tags": [
+      "hard trance",
+      "1996",
+      "Germany",
+      "Time Unlimited",
+      "acid trance"
+    ],
+    "description": "Released around 1996 on Time Unlimited, 'Blow Back (Original)' by Nostrum (Bernd Augustinski) is a seminal hard trance track, featuring driving kicks, acid-laced leads, and moody atmosphere. Highly regarded among underground trance collectors and DJs.",
+    "releaseYear": 1996,
+    "label": "Time Unlimited",
+    "album": "Cologne EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid basslines",
+      "moody pads",
+      "arpeggiated leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "acid trance",
+      "early techno",
+      "90s rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=ejKCxSrfCm8"
+    ]
+  },
+  {
+    "id": "nostrum-night-in-motion-extended-mix",
+    "title": "Night In Motion (Extended Mix)",
+    "artist": "Nostrum",
+    "tags": [
+      "trance",
+      "2000",
+      "Germany",
+      "Time Unlimited",
+      "extended mix"
+    ],
+    "description": "Released in 2000 on Time Unlimited, the 'Extended Mix' of “Night In Motion” by Nostrum (Bernd Augustinski) is a lush trance track featuring spacious atmospheric pads, driving rhythms, and evolving acid‑tinged leads. Its nearly seven‑minute duration made it a favorite for clubs and DJs.",
+    "releaseYear": 2000,
+    "label": "Time Unlimited",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "atmospheric pads",
+      "acid‑tinged leads",
+      "arpeggiated sequences"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "acid trance",
+      "progressive trance",
+      "2000s techno"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=uB7HfsBHvt8"
+    ]
+  },
+  {
+    "id": "nostrum-e-motion-original",
+    "title": "E‑Motion",
+    "artist": "Nostrum",
+    "tags": [
+      "trance",
+      "1997",
+      "Germany",
+      "Time Unlimited",
+      "deep trance"
+    ],
+    "description": "Released in 1997 on Time Unlimited, 'E‑Motion' by Nostrum (Bernd Augustinski) is a deep yet euphoric trance track, featuring captivating melodic basslines and driving rhythms. It stands out on the ‘Parish Fair’ album for its emotional uplift and dancefloor energy.",
+    "releaseYear": 1997,
+    "label": "Time Unlimited",
+    "album": "Parish Fair",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "captivating melody",
+      "deep bassline",
+      "uplifting pads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snares",
+      "hi‑hats"
+    ],
+    "influences": [
+      "deep trance",
+      "1990s German trance",
+      "euphoric melodic style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=q0Eqi7UxPCU"
+    ]
+  },
+  {
+    "id": "nostrum-seduction-original",
+    "title": "Seduction",
+    "artist": "Nostrum",
+    "tags": [
+      "trance",
+      "1994",
+      "Germany",
+      "Time Unlimited",
+      "deep trance"
+    ],
+    "description": "Released in 1994 on Time Unlimited, ‘Seduction’ by Nostrum (Bernd Augustinski) is a profound trance track featuring deep hypnotic sequences, emotive pads, and a driving groove. Clocking in at just over seven minutes, the track solidified its place in the early German trance movement.",
+    "releaseYear": 1994,
+    "label": "Time Unlimited",
+    "album": "EP 3.1",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "hypnotic pads",
+      "emotive leads",
+      "understated arpeggios"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "subtle hi‑hats"
+    ],
+    "influences": [
+      "deep trance",
+      "early 1990s German trance",
+      "emotional techno"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Deep Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=46KVBOLW9DI"
+    ]
+  },
+  {
+    "id": "nostrum-melodrama-original",
+    "title": "Melodrama",
+    "artist": "Nostrum",
+    "tags": [
+      "trance",
+      "2001",
+      "Germany",
+      "Time Unlimited",
+      "extended mix"
+    ],
+    "description": "Released in 2001 on Time Unlimited, ‘Melodrama’ by Nostrum (Bernd Augustinski) is a lush, hypnotic trance track blending sweeping pads, emotive melodies, and driving rhythms. A standout from the *Last Exit → Trance* series, it's celebrated in underground trance circles.",
+    "releaseYear": 2001,
+    "label": "Time Unlimited",
+    "album": "Last Exit → Trance",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "sweeping pads",
+      "emotive leads",
+      "melodic arpeggio"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "2000s trance",
+      "melodic trance",
+      "German underground"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=jsf1NH5A3po"
+    ]
+  },
+  {
+    "id": "nostrum-monastery-original",
+    "title": "Monastery",
+    "artist": "Nostrum",
+    "tags": [
+      "trance",
+      "1996",
+      "Germany",
+      "Time Unlimited",
+      "acid trance"
+    ],
+    "description": "Released in 1996 on Time Unlimited, “Monastery” by Nostrum (Bernd Augustinski) is a hypnotic acid‑tinged trance track. It blends brooding pads, reverberant arpeggios, and rolling driving rhythms into a moody and immersive listening experience—a classic of underground German trance.",
+    "releaseYear": 1996,
+    "label": "Time Unlimited",
+    "album": "Monastery EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Bernd Augustinski",
+      "Nostrum"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "reverberant arpeggios",
+      "brooding pads",
+      "acid sequences"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "acid trance",
+      "mid‑90s German techno",
+      "underground rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=-IxHMB3wczU"
+    ]
+  },
+  {
+    "id": "tc-pornstar-original",
+    "title": "Pornstar",
+    "artist": "TC",
+    "tags": [
+      "drum and bass",
+      "2008",
+      "UK",
+      "D‑Style Recordings",
+      "feat. Hannah Collins"
+    ],
+    "description": "Released in October 2008 on D‑Style Recordings, “Pornstar” by TC (Tom Casswell), featuring vocals by Hannah Collins, is a gritty, high‑energy drum & bass track with explicit, edgy lyrics and rolling basslines. Often paired with the VIP of “Borrowed Time,” it became a cult favorite among DnB fans.",
+    "releaseYear": 2008,
+    "label": "D‑Style Recordings",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Drum and Bass",
+    "aliases": [
+      "Tom Casswell",
+      "TC",
+      "Tommy Boy"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "dark pads",
+      "repeating bass stabs",
+      "edgy vocal samples"
+    ],
+    "drums": [
+      "fast breakbeats",
+      "rolling snares",
+      "sub‑bass kick"
+    ],
+    "influences": [
+      "UK hardcore DnB",
+      "bristol rave scene",
+      "explicit lyrical style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Drum and Bass",
+    "youtube": [
+      "https://www.youtube.com/watch?v=0uXN2ZJQ5M4"
+    ]
+  },
+  {
+    "id": "liquid-phog-original",
+    "title": "Phog",
+    "artist": "Liquid",
+    "tags": [
+      "breakbeat hardcore",
+      "1992",
+      "United Kingdom",
+      "XL Recordings",
+      "rave"
+    ],
+    "description": "Released in 1992 on XL Recordings, “Phog” by Liquid (Eamon Downes & Shane Henegan) is a high‑energy breakbeat hardcore track featuring rolling beats, euphoric synth stabs, and rave‑style vocal samples. It originally appeared as a B‑side to the breakthrough single “Sweet Harmony” and quickly became a cult favorite in early UK rave culture.",
+    "releaseYear": 1992,
+    "label": "XL Recordings",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat / Hardcore",
+    "aliases": [
+      "Liquid",
+      "Eamon Downes",
+      "Shane Henegan"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "euphoric synth stabs",
+      "rave vocal samples",
+      "bass‑heavy riffs"
+    ],
+    "drums": [
+      "fast breakbeats",
+      "snappy snares",
+      "shuffled kicks"
+    ],
+    "influences": [
+      "UK rave",
+      "breakbeat hardcore",
+      "early 90s rave culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Breakbeat Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=4AKMGlGuk_M"
+    ]
+  },
+  {
+    "id": "sonz-of-a-loop-da-loop-era-higher",
+    "title": "Higher",
+    "artist": "Sonz of a Loop Da Loop Era",
+    "tags": [
+      "breakbeat hardcore",
+      "1991",
+      "UK",
+      "Suburban Base",
+      "hardcore rave"
+    ],
+    "description": "Released in 1991 on Suburban Base, “Higher” by Sonz of a Loop Da Loop Era (Danny Breaks) is a breakbeat‑driven hardcore rave anthem featuring chopped vocal samples, punchy piano stabs, and energetic rhythm. It served as the AA‑side to the hit “Far Out” and became iconic in early UK hardcore culture.",
+    "releaseYear": 1991,
+    "label": "Suburban Base Records",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat / Hardcore",
+    "aliases": [
+      "Danny Breaks",
+      "Sonz of a Loop Da Loop Era"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": null,
+      "UK Dance Singles Chart": null
+    },
+    "synths": [
+      "piano stabs",
+      "chopped vocal samples"
+    ],
+    "drums": [
+      "fast breakbeats",
+      "shuffled kicks",
+      "snappy snares"
+    ],
+    "influences": [
+      "UK rave culture",
+      "early 90s hardcore",
+      "hip hop sampling"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Breakbeat Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=v5wvwaOVMds"
+    ]
+  },
+  {
+    "id": "dj-bjonik-potsdamer-platz-original",
+    "title": "Potsdamer Platz",
+    "artist": "DJ Bjonik",
+    "tags": [
+      "trance",
+      "2000",
+      "Germany",
+      "A45 Music",
+      "classic trance"
+    ],
+    "description": "Released in 2000 on A45 Music, 'Potsdamer Platz' by DJ Bjonik is a deep, melodic trance track with spacious pads, euphoric arpeggios, and rolling rhythms. Its evocative title references the iconic Berlin square, creating a blend of urban atmosphere and emotional trance energy.",
+    "releaseYear": 2000,
+    "label": "A45 Music",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Bjonik",
+      "Kai van Bjonik"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "euphoric arpeggios",
+      "spacious pads",
+      "melodic leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "hi‑hats"
+    ],
+    "influences": [
+      "German trance",
+      "Berlin ambience",
+      "early 2000s trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=evzONw637hg"
+    ]
+  },
+  {
+    "id": "amen-uk-passion-baby-doc-remix",
+    "title": "Passion (Baby Doc Remix)",
+    "artist": "Amen! UK",
+    "tags": [
+      "acid trance",
+      "1997",
+      "UK",
+      "Feverpitch",
+      "trance"
+    ],
+    "description": "Released in January 1997 on the Feverpitch label, the 'Baby Doc Remix' of \"Passion\" by Amen! UK (Paul Masterson) revisits the original with an acid-tinged trance treatment. It delivers hypnotic 303 lines, driving trance beats, and trance‑era euphoric breakdowns—capturing late‑90s UK trance energy.",
+    "releaseYear": 1997,
+    "label": "Feverpitch",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Amen! UK",
+      "Paul Masterson"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑line 303",
+      "hypnotic pads",
+      "euphoric leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "rolling hi-hats"
+    ],
+    "influences": [
+      "acid trance",
+      "late‑90s UK trance",
+      "rave culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=sgp9_f2NaJY"
+    ]
+  },
+  {
+    "id": "nemo-spacemaker-push-remix",
+    "title": "Spacemaker (Push Remix)",
+    "artist": "Nemo",
+    "tags": [
+      "trance",
+      "1999",
+      "UK",
+      "Eve Nova",
+      "progressive trance"
+    ],
+    "description": "Released in 1999 on UK label Eve Nova, “Spacemaker (Push Remix)” by Nemo delivers soaring trance energy with crisp production, ethereal pads, and melodic arpeggios. A defining track in late‑90s progressive and uplifting trance scenes.",
+    "releaseYear": 1999,
+    "label": "Eve Nova (EVE NOVA 002)",
+    "album": "Spacemaker / Long Range",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Nemo"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "ethereal pads",
+      "melodic arpeggios",
+      "sweeping leads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy snares",
+      "rolling hi-hats"
+    ],
+    "influences": [
+      "late 90s trance",
+      "UK progressive trance",
+      "push remix style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=b4QO93ZI_xE"
+    ]
+  },
+  {
+    "id": "dj-hitch-hiker-abel-kain-twilight-zone-dumondt-remix",
+    "title": "Twilight Zone (Hitch Hiker & Dumondt Remix)",
+    "artist": "DJ Hitch Hiker vs. Abel & Kain",
+    "tags": [
+      "trance",
+      "1999",
+      "Germany",
+      "Velvet Vibe",
+      "acid trance"
+    ],
+    "description": "Remixed in 1999 by Hitch Hiker & Dumondt, this version of “Twilight Zone” by DJ Hitch Hiker vs. Abel & Kain delivers lush acid‑tinged trance vibes—complete with hypnotic 303 lines, swirling pads, and an evocative late‑90s trance groove.",
+    "releaseYear": 1999,
+    "label": "Velvet Vibe Recordings",
+    "album": "Inside My Soul / Twilight Zone",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Hitch Hiker",
+      "Abel & Kain",
+      "Jacques Dumondt"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑line 303",
+      "hypnotic pads",
+      "swirling leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "acid trance",
+      "late‑90s European trance",
+      "Velvet Vibe sound"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=XN6ivOaRJ2g"
+    ]
+  },
+  {
+    "id": "astrobug-one-original",
+    "title": "One!",
+    "artist": "Astrobug",
+    "tags": [
+      "trance",
+      "1999",
+      "UK",
+      "Paradigm Shift",
+      "acid trance"
+    ],
+    "description": "Released in 1999 on Paradigm Shift Recordings, “One!” by Astrobug (M. Miezavs & S. Hockey) blends acid‑trance energy with rolling hard‑trance rhythms. A cult favorite in underground trance circles, it’s celebrated for its hypnotic sequences and trippy atmosphere.",
+    "releaseYear": 1999,
+    "label": "Paradigm Shift Recordings",
+    "album": null,
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Astrobug",
+      "M. Miezavs",
+      "S. Hockey"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid riffs",
+      "hypnotic pads",
+      "trippy leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "acid trance",
+      "hard trance",
+      "late‑90s UK trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=4-IZ6RQWwYE"
+    ]
+  },
+  {
+    "id": "untouchable-warriors-no-pain-original",
+    "title": "No Pain",
+    "artist": "Untouchable Warriors",
+    "tags": [
+      "trance",
+      "1995",
+      "Germany",
+      "Frankfurt Beat Productions",
+      "hard trance"
+    ],
+    "description": "Released in 1995 via Germany’s Frankfurt Beat Productions, “No Pain” by Untouchable Warriors (Massimo Vivona) is a driving, hard‑trance anthem featuring acidic 303 lines, hypnotic pads, and peak‑time energy—classic mid‑90s European trance.",
+    "releaseYear": 1995,
+    "label": "Frankfurt Beat Productions",
+    "album": "Never Die / No Pain",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Untouchable Warriors",
+      "Massimo Vivona"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid arpeggios",
+      "hypnotic pads",
+      "euphoric stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "hard trance",
+      "1990s German trance",
+      "underground rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=dpnOOVxDCwg"
+    ]
+  },
+  {
+    "id": "uct-mind-overflow-microbots-remix",
+    "title": "Mind Overflow (Microbots Remix)",
+    "artist": "U.C.T.",
+    "tags": [
+      "trance",
+      "1993",
+      "Germany",
+      "Time Unlimited",
+      "acid trance"
+    ],
+    "description": "Originally released in 1993 on Time Unlimited within the ‘Stronglimited’ compilation series, this Microbots remix of “Mind Overflow” by U.C.T. (Joachim Keil, Miguel Abel, Konrad Best & Frank Rohnacher) features hypnotic acid‑line 303, pulsing pads, and a tight driving trance groove emblematic of early German trance.",
+    "releaseYear": 1993,
+    "label": "Time Unlimited",
+    "album": "Stronglimited (Various Artists)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "U.C.T.",
+      "Microbots Remix"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑303 lines",
+      "hypnotic pads",
+      "atmospheric textures"
+    ],
+    "drums": [
+      "4/4 kick",
+      "tight snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "early 90s trance",
+      "acid trance",
+      "German underground"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=lF428OMQg4o"
+    ]
+  },
+  {
+    "id": "caesar-t-energy-part-1",
+    "title": "T Energy (Part 1)",
+    "artist": "Caesar",
+    "tags": [
+      "trance",
+      "2000",
+      "Germany",
+      "Various Artists",
+      "compilation"
+    ],
+    "description": "Originally released in 2000 via a various‑artists compilation, “T Energy (Part 1)” by Caesar is a trance track showcasing uplifting pads, rhythmic arpeggios, and classic early‑2000s club energy. Included on the CD compilation *Trance 100 9: Best Of The Best*, it captures the era’s peak trance vibe.",
+    "releaseYear": 2000,
+    "label": "Various Artists (Trance 100 9 compilation)",
+    "album": "Trance 100 9: Best Of The Best",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Caesar"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "uplifting pads",
+      "arpeggiated melodies",
+      "ambient stabs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "late‑90s/early‑00s trance",
+      "German club trance",
+      "compilation culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=irZLwLDpinQ"
+    ]
+  },
+  {
+    "id": "french-traxx-maes-traxx-original",
+    "title": "Maes Traxx",
+    "artist": "French Traxx",
+    "tags": [
+      "trance",
+      "1994",
+      "France",
+      "Peek‑A‑Boo Records",
+      "hard trance"
+    ],
+    "description": "Released in 1994 on Peek‑A‑Boo Records (catalog PK 70013), ‘Maes Traxx’ by French Traxx is an early hard‑trance track featuring acid‑tinged lead synths, driving 4/4 rhythms, and classic early‑’90s energy—a hidden gem in French trance for its energy and raw production.",
+    "releaseYear": 1994,
+    "label": "Peek‑A‑Boo Records",
+    "album": "Special Hardbeats",
+    "country": "France",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Frenchtraxx",
+      "French Traxx"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑style lead synth",
+      "staccato pads",
+      "rave stabs"
+    ],
+    "drums": [
+      "fast 4/4 kick",
+      "snappy snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "early hard trance",
+      "French rave scene",
+      "acid trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=qIVOm2W2Mew"
+    ]
+  },
+  {
+    "id": "baby-violent-inspiration-original",
+    "title": "Inspiration",
+    "artist": "Baby Violent",
+    "tags": [
+      "hard trance",
+      "1997",
+      "Italy",
+      "Go Ahead Records",
+      "trance"
+    ],
+    "description": "Released in 1997 on Italy’s Go Ahead Records (catalog GOA 007), “Inspiration” by Baby Violent is a hard‑trance track driven by energetic acid riff lines, atmospheric pads, and euphoric breakdowns. A cult classic from Italian trance in the late 90s.",
+    "releaseYear": 1997,
+    "label": "Go Ahead Records",
+    "album": null,
+    "country": "Italy",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Baby Violent"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid riff lines",
+      "atmospheric pads",
+      "euphoric stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "Italian trance",
+      "hard trance",
+      "1990s rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=EHJzRZLlj78"
+    ]
+  },
+  {
+    "id": "sound-scape-deliorman-original",
+    "title": "Deliorman",
+    "artist": "Sound Scape",
+    "tags": [
+      "progressive trance",
+      "1996",
+      "Germany",
+      "Time Unlimited",
+      "hypnotic trance"
+    ],
+    "description": "Released in 1996 on Time Unlimited, “Deliorman” by Sound Scape (Frank Thelen & Klaus Krumme) is a progressive trance gem with swirling pads, melodic atmospherics, and a hypnotic groove. A standout from the Deliorman EP, it's beloved in classic trance circles.",
+    "releaseYear": 1996,
+    "label": "Time Unlimited",
+    "album": "Deliorman EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Sound Scape",
+      "SoundScape"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "swirling pads",
+      "atmospheric leads",
+      "melodic arpeggios"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "rolling snares",
+      "hi‑hats"
+    ],
+    "influences": [
+      "progressive trance",
+      "mid‑90s German trance",
+      "deep club sounds"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=rvv3dVnAvjo"
+    ]
+  },
+  {
+    "id": "sienna-arcs-in-circles-original",
+    "title": "Arcs in Circles",
+    "artist": "Sienna",
+    "tags": [
+      "trance",
+      "1999",
+      "UK",
+      "Halogen",
+      "progressive trance"
+    ],
+    "description": "Released in December 1999 on UK label Halogen (catalog HALO:001), “Arcs in Circles” by Sienna is a lush progressive trance track featuring swirling pads, euphoric arpeggios, and emotive atmospheres. It’s a standout from the overlooked *Hard Evidence* release and appreciated in classic trance collector circles.",
+    "releaseYear": 1999,
+    "label": "Halogen",
+    "album": "Hard Evidence",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Sienna"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "swirling pads",
+      "euphoric arpeggios",
+      "atmospheric leads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "rolling snares",
+      "shuffled hi‑hats"
+    ],
+    "influences": [
+      "progressive trance",
+      "late‑90s UK trance",
+      "Club Atlantis era"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Progressive Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=qLd79cT9mcQ"
+    ]
+  },
+  {
+    "id": "eqt-far-beyond-grosser-club-mix",
+    "title": "Far Beyond (Grosser Club Mix)",
+    "artist": "EQT",
+    "tags": [
+      "trance",
+      "1997",
+      "Germany",
+      "Cosmic Cubes / Sub Terranean",
+      "euphoric trance"
+    ],
+    "description": "Released in 1997 on the Sub Terranean/Cosmic Cubes compilation series, “Far Beyond (Grosser Club Mix)” by EQT (Martin “YOMC” Röth) is a driving trance anthem—packed with euphoric leads, sweeping pads, and uplifting energy, it became a staple in late‑90s trance sets.",
+    "releaseYear": 1997,
+    "label": "Cosmic Cubes / Sub Terranean",
+    "album": "Cosmic Cubes – A Cosmic Trance Compilation Vol. V",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "EQT",
+      "Martin YOMC Röth"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "euphoric leads",
+      "swirling pads",
+      "uplifting arpeggios"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "late‑90s euphoric trance",
+      "Cosmic Cubes compilations",
+      "German trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=hf7isR5Lkzg"
+    ]
+  },
+  {
+    "id": "synergy-flash-light-extended-mix",
+    "title": "Flash Light (Extended Mix)",
+    "artist": "Synergy",
+    "tags": [
+      "trance",
+      "1996‑1997",
+      "Belgium/France",
+      "Bonka Records / Dance Pool",
+      "classic trance"
+    ],
+    "description": "Released in the mid‑90s on Bonka Records (Belgium) and Dance Pool (France), the Extended Mix of “Flash Light” by Synergy is a driving trance cut featuring lush pads, euphoric arpeggios, and rolling rhythms. A cult classic from the vintage trance era often played by early Belgian/Dutch DJs.",
+    "releaseYear": 1996,
+    "label": "Bonka Records (BEL) / Dance Pool (FRA)",
+    "album": null,
+    "country": "Belgium / France",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Synergy"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "euphoric pads",
+      "acid‑style arpeggios",
+      "atmospheric leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "early Belgian trance",
+      "Euro‑trance mid‑90s",
+      "rave ambience"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=AMsvxDpggMc"
+    ]
+  },
+  {
+    "id": "chris-c-jon-doe-mitsubishi-baby-eurotrance-mix",
+    "title": "Mitsubishi Baby (Eurotrance Mix)",
+    "artist": "Chris C & Jon Doe",
+    "tags": [
+      "trance",
+      "1999",
+      "UK",
+      "Endeavour Records",
+      "hard trance"
+    ],
+    "description": "Released in 1999 on the UK’s Endeavour label (catalog ENDV002), the Eurotrance Mix of “Mitsubishi Baby” by Chris C & Jon Doe delivers driving hard/trance energy, euphoric arpeggios, and stadium-like synth stabs. Known in underground trance circles for its cinematic build‑up and dancefloor impact.",
+    "releaseYear": 1999,
+    "label": "Endeavour Records",
+    "album": "Mitsubishi Baby 12\"",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Chris C",
+      "Jon Doe"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "euphoric arpeggios",
+      "cinematic stabs",
+      "anthemic leads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy snares",
+      "fast hi‑hats"
+    ],
+    "influences": [
+      "late‑90s hard trance",
+      "UK rave",
+      "Eurotrance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=hxGaJAwDu60"
+    ]
+  },
+  {
+    "id": "alpha-crime-follow-me-dj-mind-x-remix",
+    "title": "Follow Me (DJ Mind‑X Remix)",
+    "artist": "Alpha Crime",
+    "tags": [
+      "dream trance",
+      "uplifting trance",
+      "1999",
+      "Switzerland",
+      "Harem Records",
+      "melodic trance"
+    ],
+    "description": "Released in 1999 on Harem Records (catalog HAR 023‑6), the DJ Mind‑X Remix of “Follow Me” by Alpha Crime delivers soaring melodies, euphoric pads, and a floating club groove. It stands as a quintessential example of Swiss dream trance and was championed by Mind‑X in late‑90s trance circuits.",
+    "releaseYear": 1999,
+    "label": "Harem Records",
+    "album": "Follow Me 12\" Single",
+    "country": "Switzerland",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Alpha Crime"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "melodic arpeggios",
+      "euphoric pads",
+      "dreamy lead synths"
+    ],
+    "drums": [
+      "4/4 kick",
+      "soft snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "Swiss trance",
+      "dream trance",
+      "late‑90s club trance"
+    ],
+    "genre": "Trance",
+    "subgenre": "Dream Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=teGEJpkk0As"
+    ]
+  },
+  {
+    "id": "jfs-praxis-saturn-mix",
+    "title": "Praxis (Saturn Mix)",
+    "artist": "JFS",
+    "tags": [
+      "hard trance",
+      "1998",
+      "Germany",
+      "Tunnel Records",
+      "acid trance"
+    ],
+    "description": "Released December 28, 1998 on Tunnel Records (catalog TR 3034), “Praxis (Saturn Mix)” by JFS is a driving late‑90s hard trance cut, featuring pulsing acid lines, energetic breakdowns, and a high‑octane club vibe. A standout B‑side to the ‘Obsession’ release, it's known for its intensity and underground DJ appeal.",
+    "releaseYear": 1998,
+    "label": "Tunnel Records",
+    "album": "Obsession 12\" single",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "JFS"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid lines",
+      "energetic pads",
+      "driving lead synths"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "German hard trance",
+      "acid trance",
+      "late‑90s underground"
+    ],
+    "genre": "Trance",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=ENo4yHisjJM"
+    ]
+  },
+  {
+    "id": "seraphim-codex-phantom-power-original",
+    "title": "Phantom Power",
+    "artist": "Seraphim Codex",
+    "tags": [
+      "trance",
+      "1994",
+      "Croatia",
+      "Loving Ed Records",
+      "hard trance"
+    ],
+    "description": "Released in 1994 on Croatia’s Loving Ed Records (catalog L.E.R. 07), “Phantom Power” by Seraphim Codex is a hard‑trance gem—packed with manic acid sequences, atmospheric pads, and propulsive rhythms. A rare vinyl-only release cherished by trance collectors.",
+    "releaseYear": 1994,
+    "label": "Loving Ed Records",
+    "album": null,
+    "country": "Croatia",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Seraphim Codex",
+      "Deity (producer alias)"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid 303 lines",
+      "atmospheric pads",
+      "moody lead sequences"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "hard trance",
+      "early‑90s acid trance",
+      "underground European trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Ab0wSitgoEc"
+    ]
+  },
+  {
+    "id": "nymphomania-masturbation-maniac-alex-tune-remix",
+    "title": "Masturbation Maniac (Alex Tune Remix)",
+    "artist": "Nymphomania feat. Urban Baal",
+    "tags": [
+      "acid trance",
+      "1994",
+      "Belgium/Netherlands",
+      "DOS Records",
+      "underground trance"
+    ],
+    "description": "Released in 1994 on DOS Records, the Alex Tune Remix of “Masturbation Maniac” by Nymphomania feat. Urban Baal delivers driving acid‑flavored trance with hypnotic 303 sequences, tight rhythms, and pulsing energy—a cult classic of early‑90s underground Euro trance.",
+    "releaseYear": 1994,
+    "label": "DOS Records",
+    "album": null,
+    "country": "Belgium/Netherlands",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Nymphomania feat. Urban Baal"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid 303 riffs",
+      "hypnotic pads",
+      "pulsing lead loops"
+    ],
+    "drums": [
+      "fast 4/4 kick",
+      "snappy snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "early acid trance",
+      "Belgian rave scene",
+      "1990s underground trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=-ZMRAZU--9Y"
+    ]
+  },
+  {
+    "id": "cooky-old-damn-house-norman-pain-cutmix",
+    "title": "Old Damn House (Norman & Pain Cutmix)",
+    "artist": "Cooky",
+    "tags": [
+      "trance",
+      "1997",
+      "Germany",
+      "Drizzly / DOS Records",
+      "hard trance"
+    ],
+    "description": "Released in 1997 on Germany's Drizzly label (catalog DRIZ9710/17) and also featured on the compilation *Club Base 2*, the Norman & Pain Cutmix of “Old Damn House” by Cooky is a high‑energy trance remix by Norman & DJ Pain—extending to ~8:04 minutes with chopped edits, driving rhythms, and acid-tinged motifs that made it a favorite in techno‑trance sets.",
+    "releaseYear": 1997,
+    "label": "Drizzly Records / DOS Records",
+    "album": "Old Damn House 12\" single",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Cooky"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid motifs",
+      "chopped synth loops",
+      "energetic stabs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "late‑90s hard trance",
+      "German club trance",
+      "Norman & Pain remix style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=ov4YdF4mTNI"
+    ]
+  },
+  {
+    "id": "dark-at8-dreams-minimum-dream",
+    "title": "Dreams (Minimum Dream)",
+    "artist": "Dark A.T.8",
+    "tags": [
+      "trance",
+      "1996",
+      "Germany",
+      "Deep Zone Records",
+      "hard trance",
+      "minimum dream mix"
+    ],
+    "description": "Released in 1996 on Deep Zone Records, “Dreams (Minimum Dream)” by Dark A.T.8 is a tight, driving trance cut featuring minimal acid lines, hypnotic atmospherics, and punchy club energy. The remix stands apart with its stripped‑down structure and harder edge compared to the fuller ‘Maximum Dream’ version.",
+    "releaseYear": 1996,
+    "label": "Deep Zone Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Dark A.T.8",
+      "Dark AT8"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "minimal acid stabs",
+      "hypnotic pads",
+      "subtle lead motifs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "tight snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "hard trance",
+      "1990s European underground trance",
+      "minimal trance"
+    ],
+    "genre": "Trance",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=nSGQbrbj4Sw"
+    ]
+  },
+  {
+    "id": "dark-at8-slave-2-the-rhythm-airplay-mix",
+    "title": "Slave 2 The Rhythm (Airplay Mix)",
+    "artist": "Dark A.T.8",
+    "tags": [
+      "hard trance",
+      "1995",
+      "Germany",
+      "Deep Zone Records",
+      "airplay mix"
+    ],
+    "description": "Released in 1995 on Germany’s Deep Zone Records, the Airplay Mix of “Slave 2 The Rhythm” by Dark A.T.8 is a concise hard-trance version (~4:26) featuring truncated staccato vocal snippets, an energetic driving kick, and a polished radio-oriented structure—distinct from the longer Stakkato Mix.",
+    "releaseYear": 1995,
+    "label": "Deep Zone Records",
+    "album": "Slave 2 The Rhythm (12\" single)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Dark A.T.8"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "staccato vocal snippets",
+      "acid-charged motifs",
+      "energetic lead stabs"
+    ],
+    "drums": [
+      "tight 4/4 kick",
+      "quick snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "mid‑90s German hard trance",
+      "industrial vocal trance",
+      "Radio Edit style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=K4tMe3JklaA"
+    ]
+  },
+  {
+    "id": "stardust-music-sounds-better-with-you-radio-edit",
+    "title": "Music Sounds Better with You (Radio Edit)",
+    "artist": "Stardust",
+    "tags": [
+      "French house",
+      "1998",
+      "France",
+      "Roulé",
+      "dance-pop"
+    ],
+    "description": "Released July 20, 1998 on Thomas Bangalter’s French label Roulé (later Virgin/Because), “Music Sounds Better with You (Radio Edit)” by Stardust (Alan Braxe, Thomas Bangalter, Benjamin Diamond) is a seminal French‑house anthem built around a filtered Chaka Khan “Fate” guitar loop, polished Rhodes chords, and minimal rhythmic accompaniment—capturing euphoric bliss in under 5 minutes.",
+    "releaseYear": 1998,
+    "label": "Roulé (Virgin/Because)",
+    "album": null,
+    "country": "France",
+    "artistBorn": null,
+    "artistPrimaryGenre": "House",
+    "aliases": [
+      "Stardust"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": 2,
+      "US Dance Club Play": 1
+    },
+    "synths": [
+      "filtered guitar loop",
+      "Rhodes piano chords"
+    ],
+    "drums": [
+      "steady kick",
+      "claps",
+      "hi‑hat groove"
+    ],
+    "influences": [
+      "French touch",
+      "disco sampling",
+      "house soul"
+    ],
+    "genre": "Electronic",
+    "subgenre": "French House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=EvHzRASaCxs"
+    ]
+  },
+  {
+    "id": "baby-d-let-me-be-your-fantasy-radio-edit",
+    "title": "Let Me Be Your Fantasy (Radio Edit)",
+    "artist": "Baby D",
+    "tags": [
+      "rave",
+      "breakbeat hardcore",
+      "1994",
+      "UK",
+      "Systematic",
+      "happy hardcore"
+    ],
+    "description": "Originally released in 1992, Baby D’s “Let Me Be Your Fantasy” became a UK No. 1 hit upon its re‑release in November 1994 via Systematic Records. The Radio Edit (~3:52) captures the classic breakbeat hardcore energy melded with powerful diva vocals, massive pianos, and euphoric melody—a defining anthem of the UK rave era.",
+    "releaseYear": 1994,
+    "label": "Systematic (London Records)",
+    "album": "Deliverance",
+    "country": "United Kingdom",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Breakbeat / Rave",
+    "aliases": [
+      "Baby D"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": 1,
+      "UK Dance Singles Chart": 1,
+      "Eurochart Hot 100": 5
+    },
+    "synths": [
+      "massive piano chords",
+      "filtered pads"
+    ],
+    "drums": [
+      "breakbeat kicks",
+      "snappy snares"
+    ],
+    "influences": [
+      "UK rave",
+      "happy hardcore",
+      "jungle-lite"
+    ],
+    "genre": "Dance",
+    "subgenre": "Breakbeat Hardcore",
+    "youtube": [
+      "https://www.youtube.com/watch?v=tuC7MBmhR0A"
+    ]
+  },
+  {
+    "id": "tiga-zyntherius-sunglasses-at-night-radio-edit",
+    "title": "Sunglasses at Night (Radio Edit)",
+    "artist": "Tiga & Zyntherius",
+    "tags": [
+      "electro house",
+      "2001",
+      "Canada/Finland",
+      "Turbo Recordings",
+      "electro"
+    ],
+    "description": "Released November 4, 2001 on Turbo Recordings, Tiga & Zyntherius’ cover of Corey Hart’s “Sunglasses at Night” became a breakthrough electro‑house single. The Radio Edit (~3:43) blends iconic synth riffing with dancefloor sensibility, and charted internationally as a modern electro anthem.",
+    "releaseYear": 2001,
+    "label": "Turbo Recordings",
+    "album": "Sunglasses at Night single",
+    "country": "Canada / Finland",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Electro House",
+    "aliases": [
+      "Tiga",
+      "Zyntherius"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": 25,
+      "UK Dance Singles Chart": 2
+    },
+    "synths": [
+      "synth hook riff",
+      "electro leads",
+      "filtered pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "claps",
+      "tight hi‑hats"
+    ],
+    "influences": [
+      "80s synth‑pop",
+      "electro revival",
+      "dancefloor house"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Electro House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=vCcfVvU0G_M"
+    ]
+  },
+  {
+    "id": "dj-crack-space-people-2000-iridium-gold-mix",
+    "title": "Space People 2000 (Iridium Gold Mix)",
+    "artist": "DJ Crack",
+    "tags": [
+      "trance",
+      "2000",
+      "Germany",
+      "Full‑E Records",
+      "acid trance",
+      "Iridium Gold Mix"
+    ],
+    "description": "Released in 2000 on Full‑E Records (vinyl catalog FUE‑0038‑12) and featured in various German trance compilations, the “Iridium Gold Mix” of “Space People 2000” by DJ Crack presents a more atmospheric and acid‑tinged version with ethereal pads, rolling rhythms, and a hypnotic groove. It stands out among the remixes for its ambient trance qualities.",
+    "releaseYear": 2000,
+    "label": "Full‑E Records",
+    "album": "Space People 2000 Remixes",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Crack"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid-tinged pads",
+      "atmospheric textures",
+      "ambient arpeggios"
+    ],
+    "drums": [
+      "4/4 kick",
+      "syncopated snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German trance",
+      "acid trance",
+      "ambient trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=pcJiRKn4hUI"
+    ]
+  },
+  {
+    "id": "dj-crack-century-of-e-short-mix",
+    "title": "The Century Of E (Short Mix)",
+    "artist": "DJ Crack",
+    "tags": [
+      "trance",
+      "1995",
+      "Germany",
+      "Full‑E Records",
+      "short mix"
+    ],
+    "description": "Released in 1995 on Full‑E Records, the “Short Mix” of “The Century Of E” by DJ Crack (Michael Baur) delivers a compact hard‑trance finale with acid motifs, rolling rhythm, and punchy energy—tailored for radio, promo, and DJ intro use.",
+    "releaseYear": 1995,
+    "label": "Full‑E Records",
+    "album": "The Century Of E (Single)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Crack",
+      "Michael Baur"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid lines",
+      "ambient stabs",
+      "lead motifs"
+    ],
+    "drums": [
+      "tight kick",
+      "short snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "German hard trance",
+      "acid trance",
+      "90s promo mix"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=B_wA4OXU2kg"
+    ]
+  },
+  {
+    "id": "planet-earth-vibration-cocain-remix",
+    "title": "Vibration (Cocain Remix)",
+    "artist": "Planet Earth",
+    "tags": [
+      "acid trance",
+      "1994",
+      "Germany",
+      "Planet Earth",
+      "Cocain Remix"
+    ],
+    "description": "Released in 1994 on the Planet Earth Vibration EP (Germany), the Cocain Remix delivers a cinematic acid‑trance interpretation: swirling pads, 303‑style riffs, driving rhythms and sweeping atmospherics. It's an underground favorite among classic Trance vinyl collectors.",
+    "releaseYear": 1994,
+    "label": "Planet Earth",
+    "album": "Vibration EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Planet Earth"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑303 riffs",
+      "swirling pads",
+      "atmospheric leads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "early German acid trance",
+      "1990s underground trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=_1GmSXreqVM"
+    ]
+  },
+  {
+    "id": "cherry-moon-trax-house-of-house-secret-development-remix",
+    "title": "The House of House (Secret Development Remix)",
+    "artist": "Cherry Moon Trax (feat. Secret Development)",
+    "tags": [
+      "trance",
+      "1998‑2003",
+      "Belgium",
+      "Bonzai / Backcatalogue BVBA",
+      "remix"
+    ],
+    "description": "The Secret Development Remix of “The House of House” by Cherry Moon Trax (Yves Deruyter, Axel Stephenson & Franky Kloëck) is a euphoric trance re‑interpretation with extended atmospherics and punchy 303 embellishments. At ~8:39, this remix became popular in Bonzai remix series of the early 2000s.",
+    "releaseYear": 2003,
+    "label": "Backcatalogue BVBA (Bonzai Remix Worx compilation)",
+    "album": "The House Of House (Remastered Remixes)",
+    "country": "Belgium",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Cherry Moon Trax",
+      "Secret Development"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑303 riffs",
+      "ethereal pads",
+      "euphoric leads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "rolling snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "Belgian trance",
+      "acid trance",
+      "Bonzai remix culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=hUMrdx86HJ4"
+    ]
+  },
+  {
+    "id": "legend-b-lost-in-love-original",
+    "title": "Lost In Love (Original Mix)",
+    "artist": "Legend B.",
+    "tags": [
+      "hard trance",
+      "1994",
+      "Germany",
+      "3 Lanka Records",
+      "classic trance anthem"
+    ],
+    "description": "Released in 1994 on German label 3 Lanka, “Lost In Love” by Legend B. became a defining hard trance anthem of the mid‑90s. With its soaring, euphoric lead melodies woven over driving acid-tinged basslines, cut with emotional female vocals and uplifting breakdowns, it captures the belonging and yearning of trance’s golden era. Its monumental chord progression and crescendoing structure made it a staple in trance mix sets and compilations—one fan hailed it as “Emotional, Uplifting and just wow.” on r/ClassicTrance. Despite being underground, it charted in the UK Top 75 upon release, cementing its status as a cult classic.",
+    "releaseYear": 1994,
+    "label": "3 Lanka",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Legend B."
+    ],
+    "chartInfo": {
+      "UK Singles Chart": 42
+    },
+    "synths": [
+      "emotive lead melody",
+      "acid bassline",
+      "pad swells"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy snares",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German hard trance",
+      "90s rave ethos",
+      "uplifting trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Ije-r417EZc"
+    ]
+  },
+  {
+    "id": "traumatic-acid-voices-higher-mandala-remix",
+    "title": "Acid Voices (Higher) (Mandala Remix)",
+    "artist": "Traumatic",
+    "tags": [
+      "acid trance",
+      "1994",
+      "Germany",
+      "Noom Records",
+      "Mandala Remix"
+    ],
+    "description": "Remixed in 1994 by Mandala (Commander Tom & Ray Boyé), the “Mandala Remix” of Traumatic’s *Acid Voices (Higher)* transforms the original into a lean, hypnotic acid‑trance weapon. With its sharp 303 lines, fast tempo (~135 BPM), and spare structure, it became a beloved underground classic, prevalent in hard‑trance and rave playlists of the mid‑90s.",
+    "releaseYear": 1994,
+    "label": "Noom Records",
+    "album": "Higher EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Traumatic"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid‑303 riffs",
+      "sparse lead loops",
+      "atmospheric stabs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "tight snares",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "early German acid trance",
+      "hard trance",
+      "mid‑90s rave"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=FW0SegNkPos"
+    ]
+  },
+  {
+    "id": "alien-factory-beta-music-hangover-remix",
+    "title": "Beta Music (Hangover Remix)",
+    "artist": "Alien Factory",
+    "tags": [
+      "acid trance",
+      "1993",
+      "Germany",
+      "Generator Records",
+      "Hangover Remix"
+    ],
+    "description": "Released around 1993–94 on Germany’s Generator Records, the “Hangover Remix” of “Beta Music” by Alien Factory (Frank Möbus / Alien Factory project) reimagines the original into a hypnotic acid-trance journey. With merciless 303 riffs, propulsive rhythms, and cavernous breakdowns laden with reverb and echo, it epitomizes early Frankfurt‑style trance. Fans recall its immersive tension — a track that blurs psychedelic edges with raving energy, earning underground acclaim across European rave circuits.",
+    "releaseYear": 1993,
+    "label": "Generator Records",
+    "album": "Beta Music (The Remixes)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Alien Factory"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid 303 riffs",
+      "echoing pads",
+      "hypnotic lead loops"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "sharp snares",
+      "rolling hi-hats"
+    ],
+    "influences": [
+      "early German acid trance",
+      "Frankfurt techno",
+      "rave underground"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=IfFZJdzRoB0"
+    ]
+  },
+  {
+    "id": "quench-dreams-original-mix",
+    "title": "Dreams (Original Mix)",
+    "artist": "Quench",
+    "tags": [
+      "trance",
+      "1993",
+      "Australia",
+      "Infectious Records",
+      "Dreams",
+      "classic trance"
+    ],
+    "description": "“Dreams” is widely considered one of the earliest trance anthems. Written and produced by Australian artist Christopher J. Dolan (a.k.a. Quench), it was first released in November 1993 on the UK label Infectious Records. Blending proto‑trance synth arpeggios and emotive breakdowns over a steady 4/4 techno framework, it became a seminal underground hit across Europe, reaching #9 in France and #75 in the UK upon re‑release in 1994. Often credited as a turning point in rave culture, it helped define the emerging trance sound.",
+    "releaseYear": 1993,
+    "label": "Infectious Records",
+    "album": "Sequenchial",
+    "country": "Australia",
+    "artistBorn": "1960s‑? (Christopher J. Dolan)",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Christopher J. Dolan",
+      "Quench"
+    ],
+    "chartInfo": {
+      "France": "#9 (1994 re‑release)",
+      "UK": "#75 (1994)"
+    },
+    "synths": [
+      "arpeggiated trance lead",
+      "ambient pads",
+      "acid‑style motifs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snare or clap on 2/4",
+      "driving hi‑hats"
+    ],
+    "influences": [
+      "early trance",
+      "techno",
+      "UK rave",
+      "proto‑trance aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Early Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Xa_iOGzoY9A"
+    ]
+  },
+  {
+    "id": "commitee-trance-line-original-version",
+    "title": "Trance Line (Original Version)",
+    "artist": "Committee",
+    "tags": [
+      "trance",
+      "1994‑95",
+      "Germany/France",
+      "Full Ace Music",
+      "hard trance",
+      "sample‑based"
+    ],
+    "description": "“Trance Line” by Committee (sometimes spelled 'Commitee') is a hard‑trance track first issued on vinyl around 1994–95 via Full Ace Music (France/Germany). Built around a vocal sample from “So Get Up” by Underground Sound of Lisbon featuring Ithaka, the track combines driving 4/4 rhythms, acid-inflected synth stabs, and a cinematic breakdown that became popular in European rave circles.",
+    "releaseYear": 1995,
+    "label": "Full Ace Music / Ace Music",
+    "album": null,
+    "country": "France/Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Committee",
+      "Commitee"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid-styled stab loops",
+      "sampling of vocal vocals",
+      "synthetic pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "punchy snares",
+      "driving hi-hats"
+    ],
+    "influences": [
+      "hard trance",
+      "techno",
+      "sample‑based club tracks"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=RrgWXWJRvAk"
+    ]
+  },
+  {
+    "id": "dj-merlin-energizer-in-my-mind",
+    "title": "In My Mind (Original Mix)",
+    "artist": "DJ Merlin & Energizer",
+    "tags": [
+      "trance",
+      "hard trance",
+      "late 1990s",
+      "Spain",
+      "classic trance"
+    ],
+    "description": "“In My Mind” is a high‑energy trance/hard‑trance track credited to DJ Merlin & Energizer, first appearing around 1999 on Spanish trance/makina compilations. Defined by hypnotic mounting synth loops, a driving 4/4 beat, and a repetitive melodic motif, it was featured on *The Tunnel E.P.* and *Pont Aeri Trilogy*, gaining traction in Spanish club and makina scenes.",
+    "releaseYear": 1999,
+    "label": null,
+    "album": "The New Project Vol. I, Session 2.1",
+    "country": "Spain",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Merlin",
+      "Energizer"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "melodic motif loops",
+      "atmospheric pads",
+      "driving hard‑trance leads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "punchy snares",
+      "energetic hi‑hats"
+    ],
+    "influences": [
+      "Spanish makina scene",
+      "late‑90s hard trance",
+      "European club compilations"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hard Trance",
+      "Makina"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=7vJ-FjsWiCU"
+    ]
+  },
+  {
+    "id": "jayc-gissa-underground-original",
+    "title": "Underground",
+    "artist": "JAYC & Gissa",
+    "tags": [
+      "electronic",
+      "2023",
+      "JAYC Records",
+      "House‑influenced",
+      "club single"
+    ],
+    "description": "“Underground” is a solo single by JAYC and Gissa, released October 20, 2023 on JAYC label. The track blends electronic club rhythms, hypnotic synth patterns and vocal snippets into a sleek, modern house-electronic vibe. Clocking in at approximately 3:14, it showcases polished production and has been featured heavily on streaming platforms and playlists across the electronic scene.",
+    "releaseYear": 2023,
+    "label": "JAYC",
+    "album": "Underground – Single",
+    "country": null,
+    "artistBorn": null,
+    "artistPrimaryGenre": "Electronic",
+    "aliases": [
+      "JAYC",
+      "Gissa"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "rolled synth chords",
+      "club bassline",
+      "vocal stabs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy claps",
+      "grooving hi‑hats"
+    ],
+    "influences": [
+      "modern house",
+      "electro‑pop",
+      "streaming‑era club sound"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "House",
+      "Electro"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=4Izd38_w3WY"
+    ]
+  },
+  {
+    "id": "lostboyjay-could-be-wrong-original",
+    "title": "Could Be Wrong",
+    "artist": "LOSTBOYJAY",
+    "tags": [
+      "deep house",
+      "2022",
+      "Canada",
+      "Polydor Records",
+      "sample‑based",
+      "dance"
+    ],
+    "description": "“Could Be Wrong” is a deep‑house single by Canadian artist LOSTBOYJAY (Jay Daillie), released December 2 2022 via Polydor Records under license by Universal. Built on a creative, mid‑tempo interpolation of Brandy’s “I Wanna Be Down,” the track melds smooth vocals, rhythmic piano loops, and a rolling pulsating groove. It gained viral traction across TikTok and streaming playlists, helping solidify LOSTBOYJAY’s emergence in electronic/dance scenes.",
+    "releaseYear": 2022,
+    "label": "Polydor Records",
+    "album": "Could Be Wrong (Single)",
+    "country": "Canada",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Deep House",
+    "aliases": [
+      "Jay Daillie",
+      "LOSTBOYJAY"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "piano‑based chords",
+      "vocal sample interpolation",
+      "atmospheric pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "soft snares/claps",
+      "light hi‑hats"
+    ],
+    "influences": [
+      "1990s R&B",
+      "contemporary deep house",
+      "viral dance‑pop aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Deep House",
+    "youtube": [
+      "https://www.youtube.com/watch?v=CYAQEJyqR7E"
+    ]
+  },
+  {
+    "id": "bk-sam-townend-drop-to-your-knees-original",
+    "title": "Drop To Your Knees (Original Mix)",
+    "artist": "BK & Sam Townend",
+    "tags": [
+      "hard house",
+      "tech house",
+      "2014‑15",
+      "UK",
+      "club single"
+    ],
+    "description": "“Drop To Your Knees” by BK & Sam Townend is a high‑energy hard‑house/tech‑house track, released around 2014–2015. Known within underground dance circuits, the track features a tight four‑on‑the‑floor beat, vocal chops commanding the dancefloor (“drop to your knees”), sharp stabs, and driving basslines. A staple on mix shows and DJ sets, it earned particular visibility via BK’s SLAM! remix variation.",
+    "releaseYear": 2014,
+    "label": null,
+    "album": null,
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard House",
+    "aliases": [
+      "BK",
+      "Sam Townend"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "staccato vocal chops",
+      "acid‑style synth stabs",
+      "dark bassline"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy claps",
+      "tech‑hi‑hats"
+    ],
+    "influences": [
+      "UK hard house",
+      "early tech‑house",
+      "club dance production"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Hard House",
+      "Tech‑House"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=X2VZshi46NE"
+    ]
+  },
+  {
+    "id": "turbine3-die-macht-volle-kraft-voraus-aggressor-remix",
+    "title": "Die Macht! (‘Volle Kraft Voraus’ Remix By Aggressor)",
+    "artist": "Turbine 3",
+    "tags": [
+      "acid trance",
+      "1999",
+      "Germany",
+      "Time Motion Trance",
+      "Aggressor Remix"
+    ],
+    "description": "An aggressive acid-trance rework of “Die Macht!” executed by Aggressor, released in 1999 under the Turbine 3 alias. The remix—titled “Volle Kraft Voraus”—appears on the Time Motion Trance 4 compilation, delivering punchy 303 lines, propulsive rhythms, and cinematic breakdowns characteristic of late-90s German acid trance.",
+    "releaseYear": 1999,
+    "label": "Time Motion Trance / compilation",
+    "album": "Time Motion Trance 4",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Turbine 3"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid 303 riffs",
+      "deep bass resonance",
+      "echoing pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "claps/snare on 2‑4",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German acid trance",
+      "hard trance aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=a6ZLSWu8NJ8"
+    ]
+  },
+  {
+    "id": "ppk-i-have-a-dream-original",
+    "title": "I Have a Dream",
+    "artist": "PPK",
+    "tags": [
+      "trance",
+      "2000",
+      "Russia",
+      "Perfecto Records",
+      "Martin Luther King sample"
+    ],
+    "description": "“I Have a Dream” by Russian trance duo PPK (Sergey Pimenov & Alexander Polyakov) was released in 2000. It incorporates spoken-word samples from Martin Luther King Jr.’s iconic speech, layered over shimmering trance textures and emotive breakdowns. The nearly 9‑minute track (≈ 8:56) appears on their album *Russian Trance: Formation* and represents a pioneering Eastern‑European trance production.",
+    "releaseYear": 2000,
+    "label": "Perfecto Records / iRecords",
+    "album": "Russian Trance: Formation",
+    "country": "Russia",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "PPK"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "ethereal pads",
+      "arpeggiated lead",
+      "uplifting chords"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare/clap on 2‑4",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "Eastern‑European trance",
+      "speech‑sample trance",
+      "early 2000s melodic trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=RMpWHJYlfKY"
+    ]
+  },
+  {
+    "id": "paraphonatic-the-past-the-present-the-future-pure-nrg-remix",
+    "title": "The Past, the Present, the Future (DJ Mellow‑D’s Pure NRG Remix)",
+    "artist": "Paraphonatic",
+    "tags": [
+      "trance",
+      "1997‑2013",
+      "Germany",
+      "EDM Records",
+      "Pure NRG Remix"
+    ],
+    "description": "A high‑energy trance re‑remix by DJ Mellow‑D—titled “Pure NRG Remix”—of Paraphonatic’s “The Past, the Present, the Future.” Originally released circa 1997 and officially re‑issued (remastered) in 2013 on EDM Records (catalog EDM 020), the remix is a driving trance anthem built around rising arpeggios, lush pads, and sweeping synth builds.",
+    "releaseYear": 1997,
+    "label": "EDM Records",
+    "album": "The Past, The Present, The Future (2013 Remastered Version)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Paraphonatic"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "arpeggiated trance lead",
+      "lush pads",
+      "energetic rising motifs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare/clap on 2‑4",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German trance",
+      "energetic remix styles"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": []
+  },
+  {
+    "id": "paraphonatic-reincarnation-the-way-we-do-original",
+    "title": "Reincarnation (The Way We Do)",
+    "artist": "Paraphonatic",
+    "tags": [
+      "hard trance",
+      "1995",
+      "Germany",
+      "Wizard Records",
+      "Reincarnation anthem"
+    ],
+    "description": "“Reincarnation (The Way We Do)” is the original anthem by Paraphonatic, released in 1995 on Wizard Records. Created as the official track for the Reincarnation Parade in Hannover, it features driving acid-style stabs, a relentless BPM, and a repeated vocal line (“the way we do”) that became emblematic of mid-'90s German hard trance. The track was heavily played in clubs and at major events, gaining underground popularity and inclusion in several high-profile compilations.",
+    "releaseYear": 1995,
+    "label": "Wizard Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard Trance",
+    "aliases": [
+      "Paraphonatic"
+    ],
+    "chartInfo": {
+      "German Dance Chart (DDC)": "#18 (1995, club rotation)"
+    },
+    "synths": [
+      "acid stabs",
+      "vocal sample hook",
+      "pulsing lead lines"
+    ],
+    "drums": [
+      "fast 4/4 kick",
+      "tight snares",
+      "driving hi‑hats"
+    ],
+    "influences": [
+      "German hard trance",
+      "Reincarnation Parade culture",
+      "anthemic event trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=WIVDqYeLAjg"
+    ]
+  },
+  {
+    "id": "paraphonatic-festival-of-the-century-riva-the-spaceman-remix",
+    "title": "Festival of the Century (Riva & The Spaceman Remix)",
+    "artist": "Paraphonatic",
+    "tags": [
+      "trance",
+      "1996",
+      "Germany",
+      "EDM Records",
+      "Riva & The Spaceman Remix"
+    ],
+    "description": "This remix brings a driving trance reinterpretation of Paraphonatic’s “Festival of the Century” by Riva & The Spaceman. Originally released in 1996 on Wizard Records, then remastered and reissued in 2013 by EDM Records, the remix delivers emotional arpeggios, lush pads, and high‑energy rhythms typical of German trance.",
+    "releaseYear": 1996,
+    "label": "Wizard Records / EDM Records",
+    "album": "Festival of the Century (2013 Remastered Version) [Remixes] EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Paraphonatic"
+    ],
+    "chartInfo": {
+      "Regional Charts": "Top 10 in Russia and Czech Republic under alias Calypso (1996)"
+    },
+    "synths": [
+      "arpeggiated lead",
+      "pad swells",
+      "uplifting trance motifs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare/clap on 2‑4",
+      "syncopated hi‑hats"
+    ],
+    "influences": [
+      "German trance style",
+      "anthemic remix interpretation",
+      "event-themed compositions"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=Pf6VV8q8Ces"
+    ]
+  },
+  {
+    "id": "paraphonatic-the-past-the-present-the-future-xtc-rave-mix",
+    "title": "The Past, the Present, the Future (XTC‑Rave Mix)",
+    "artist": "Paraphonatic",
+    "tags": [
+      "trance",
+      "1997",
+      "Germany",
+      "EDM Records",
+      "XTC‑Rave Mix"
+    ],
+    "description": "A special remix crafted as the anthem for the Ex.TC Rave in Schwerin, Germany. Paraphonatic performed the XTC‑Rave Mix live at the event. Originally released in 1997 and remastered in 2013 on EDM Records, this version combines energetic trance riffs, arpeggiated motifs, and festival-ready atmosphere.",
+    "releaseYear": 1997,
+    "label": "EDM Records",
+    "album": "The Past, The Present, The Future (Remixes) EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Paraphonatic"
+    ],
+    "chartInfo": {
+      "Regional Rave Anthem": "Ex.TC Rave anthem (1998) — official event anthem"
+    },
+    "synths": [
+      "arpeggiated trance lead",
+      "energetic rhythm motifs",
+      "uplifting trance pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare/clap on 2‑4",
+      "syncopated hi‑hats"
+    ],
+    "influences": [
+      "German trance festival anthems",
+      "energetic rave trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=tsbc4LoTjtY"
+    ]
+  },
+  {
+    "id": "dave-davis-transfiguration-original-mix",
+    "title": "Transfiguration (Original Mix)",
+    "artist": "Dave Davis",
+    "tags": [
+      "trance",
+      "hard trance",
+      "1995",
+      "Belgium",
+      "Bonzai Records"
+    ],
+    "description": "“Transfiguration” is a seminal trance/hard‑trance anthem by Belgian producer Dave Davis (a.k.a. JD Davis), released in 1995 on Bonzai Records. Defined by soaring synth leads, sweeping pads, and a thunderous drive, it captured the euphoric spirit of mid‑90s trance and became a club favorite and mix-compilation staple.",
+    "releaseYear": 1995,
+    "label": "Bonzai Records",
+    "album": null,
+    "country": "Belgium",
+    "artistBorn": "1973‑04‑13 (David Henrard)",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Dave Davis",
+      "JD Davis"
+    ],
+    "chartInfo": {
+      "Belgian Dance Chart": "#18 (1995, Bonzai club circuit)"
+    },
+    "synths": [
+      "uplifting trance lead",
+      "atmospheric pads",
+      "driving arpeggios"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "claps on 2‑4",
+      "open hi‑hats"
+    ],
+    "influences": [
+      "Belgian hard trance",
+      "Bonzai sound",
+      "mid‑90s euphoric trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=V4GOrRpxQ8Q"
+    ]
+  },
+  {
+    "id": "paragod-dj-yanny-initialize-original-mix",
+    "title": "Initialize (Original Mix)",
+    "artist": "The Paragod & DJ Yanny",
+    "tags": [
+      "hard trance",
+      "1997",
+      "Germany",
+      "Fog Area Records",
+      "classic hard trance"
+    ],
+    "description": "“Initialize” is a high-energy hard trance anthem by The Paragod & DJ Yanny, originally released in 1997 via Fog Area Records in Germany. Known for its aggressive synth stabs, pounding 4/4 rhythm, and rave-era vocal samples, it became a defining track of late-'90s German hard trance. A remastered version was reissued by EDM Records in 2014, preserving its underground legacy.",
+    "releaseYear": 1997,
+    "label": "Fog Area Records / EDM Records",
+    "album": null,
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Hard Trance",
+    "aliases": [
+      "The Paragod",
+      "DJ Yanny"
+    ],
+    "chartInfo": {
+      "German Club Charts": "#12 (1997, DDC regional hard trance ranking)"
+    },
+    "synths": [
+      "acid stabs",
+      "filtered leads",
+      "pitch-rising motifs"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy snares",
+      "shuffling hi-hats"
+    ],
+    "influences": [
+      "German hard trance",
+      "Fog Area sound",
+      "late '90s club culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Hard Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=vTBwyjJ1MLw"
+    ]
+  },
+  {
+    "id": "kai-tracid-destinys-path-energy-mix",
+    "title": "Destiny’s Path (Energy Mix)",
+    "artist": "Kai Tracid",
+    "tags": [
+      "trance",
+      "1999",
+      "Germany",
+      "Tracid Traxxx",
+      "Energy Mix"
+    ],
+    "description": "“Destiny’s Path (Energy Mix)” by German producer Kai Tracid, released in 1999 on the album *Trance & Acid*. The hard‑hitting mix features acid-tinged arpeggios, dramatic breakdowns, and a pulsing trance groove. It became one of Tracid’s early charting singles and helped define his acid‑trance signature sound.",
+    "releaseYear": 1999,
+    "label": "Tracid Traxxx",
+    "album": "Trance & Acid",
+    "country": "Germany",
+    "artistBorn": "1972‑01‑17 (Kai Franz)",
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Kai Tracid",
+      "Kai Mac Donald"
+    ],
+    "chartInfo": {
+      "Germany": "#29 (1999, Official Singles Chart)"
+    },
+    "synths": [
+      "acid trance arp",
+      "atmospheric pads",
+      "shimmering leads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "claps/snare on 2‑4",
+      "driving hi‑hats"
+    ],
+    "influences": [
+      "German acid trance",
+      "late‑90s melodic trance",
+      "Tracid’s acid‑trance style"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=NA4CtzoOBHQ"
+    ]
+  },
+  {
+    "id": "york-on-the-beach-original",
+    "title": "On the Beach (Original Mix)",
+    "artist": "York",
+    "tags": [
+      "trance",
+      "1999",
+      "Germany",
+      "Manifesto / Planet Love Records",
+      "CRW Edit"
+    ],
+    "description": "“On the Beach” by German duo York (Torsten & Jörg Stenzel), released in 1999 and licensed in the UK in 2000. Built around a sample from Chris Rea’s original, the track blends Balearic guitar hooks with trance rhythms and lush pads. The CRW Edit became the mainstream hit version, earning wide chart success and extensive compilation inclusion.",
+    "releaseYear": 1999,
+    "label": "Planet Love Records (GER), licensed to Manifesto (UK)",
+    "album": "On the Beach",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "York"
+    ],
+    "chartInfo": {
+      "UK Singles Chart": "#4 (June 2000); UK Dance Chart #1 (10 June 2000)"
+    },
+    "synths": [
+      "Balearic guitar hooks",
+      "lush pads",
+      "plucked lead arpeggios"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare/clap on 2‑4",
+      "shimmering hi‑hats"
+    ],
+    "influences": [
+      "Chris Rea sample adaptation",
+      "German melodic trance",
+      "Balearic house influence"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=bdx1fPIevN0"
+    ]
+  },
+  {
+    "id": "davie-forbes-sequential-original",
+    "title": "Sequential (Acid Trance 1998)",
+    "artist": "Davie Forbes",
+    "tags": [
+      "acid trance",
+      "1998",
+      "UK",
+      "Uprising Trance Records",
+      "hard trance"
+    ],
+    "description": "“Sequential” is a driving acid‑trance track by UK producer Davie Forbes, released in 1998 on Uprising Trance Records (catalog UPRIS T 8). Combining rolling 303 basslines, hard-hitting rhythms, and euphoric trance motifs, it captures the sound of late‑90s acid-infused trance.",
+    "releaseYear": 1998,
+    "label": "Uprising Trance Records",
+    "album": "Octave Kitten / Sequential",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Davie Forbes",
+      "David Forbes"
+    ],
+    "chartInfo": {
+      "UK Club Charts": "Top 15 in regional UK hard trance rotation (1998)"
+    },
+    "synths": [
+      "acid‑style 303 bassline",
+      "atmospheric trance pads",
+      "arpeggiated lead loops"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "accented snares/claps",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "UK hard‑trance",
+      "acid trance aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=NfpR3mrnQ6A"
+    ]
+  },
+  {
+    "id": "emmanuel-top-acid-phase-kai-tracid-remix",
+    "title": "Acid Phase (Kai Tracid Remix)",
+    "artist": "Emmanuel Top",
+    "tags": [
+      "acid trance",
+      "1994‑2002",
+      "France/Germany",
+      "Attack Records / Kosmo Records",
+      "Kai Tracid Remix"
+    ],
+    "description": "Kai Tracid’s remix of Emmanuel Top’s acid‑classic “Acid Phase” delivers pulsing 303 patterns and euphoric trance energy. Originally released in 1994 on Attack Records and later reissued in 2002 on Kosmo Records, the remix runs approximately 6:37 and showcases a fusion of acid techno grit with melodic trance flair.",
+    "releaseYear": 1994,
+    "label": "Attack Records (orig), Kosmo Records (2002 Remix)",
+    "album": "Acid Phase Remixes",
+    "country": "France / Germany",
+    "artistBorn": "1971‑10‑30 (Emmanuel Top)",
+    "artistPrimaryGenre": "Acid Trance",
+    "aliases": [
+      "Emmanuel Top",
+      "E. Top"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "acid 303 bassline",
+      "resonant filter stabs",
+      "trance-style pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "punchy claps/snare",
+      "bright hi‑hats"
+    ],
+    "influences": [
+      "acid techno",
+      "German trance remix aesthetic",
+      "90s rave culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=XxVDyElrnGk"
+    ]
+  },
+  {
+    "id": "the-blue-piano-blue-ballad-piano-version",
+    "title": "Blue Ballad (Piano Version)",
+    "artist": "The Blue Piano",
+    "tags": [
+      "hard trance",
+      "1996",
+      "UK",
+      "Uprising Trance Records",
+      "Piano Version"
+    ],
+    "description": "“Blue Ballad (Piano Version)” is a piano‑oriented reinterpretation of The Blue Piano’s hard‑trance track from 1996, released on Uprising Trance Records (catalog UPRIS T 8). At about 4:24 in duration, the piano version strips away the harder elements in favor of a melodic piano rendition retaining trance‑infused chord progressions.",
+    "releaseYear": 1996,
+    "label": "Uprising Trance Records",
+    "album": "Octave Kitten / Blue Ballad",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "The Blue Piano"
+    ],
+    "chartInfo": {
+      "UK Club Chart": "Top 20 rotation in acid trance sets (1996)"
+    },
+    "synths": [
+      "piano-driven melody",
+      "trance chord voicings"
+    ],
+    "drums": [
+      "omitted (piano‑only version)"
+    ],
+    "influences": [
+      "UK acid trance",
+      "hard trance melodic reinterpretations"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Trance",
+      "Piano Version"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=NfpR3mrnQ6A"
+    ]
+  },
+  {
+    "id": "leroy-the-first-flight-original",
+    "title": "The First Flight",
+    "artist": "Leroy",
+    "tags": [
+      "trance",
+      "1993",
+      "Italy",
+      "DJ Leroy",
+      "classic trance"
+    ],
+    "description": "“The First Flight” is a trance single by DJ Leroy, released in 1993 on vinyl in Italy. Known for its melodic trance progression, driving beat, and atmospheric energy, it remains a cult favorite in classic trance circles and is featured in regional club playlists.",
+    "releaseYear": 1993,
+    "label": "DJ Leroy (self‑released)",
+    "album": "The First Flight – Single",
+    "country": "Italy",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "DJ Leroy",
+      "Leroy"
+    ],
+    "chartInfo": {
+      "Italian Dance Circle Rotation": "Top 20 in regional Italian club charts (1993)"
+    },
+    "synths": [
+      "uplifting trance lead",
+      "ambient pads",
+      "arpeggiated motifs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "clap/snare on 2‑4",
+      "sparse hi‑hats"
+    ],
+    "influences": [
+      "early 90s trance",
+      "Italian trance singles",
+      "club-focused trance production"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": []
+  },
+  {
+    "id": "alien-factory-scraper-original",
+    "title": "Scraper (Original Mix)",
+    "artist": "Alien Factory",
+    "tags": [
+      "acid trance",
+      "1998",
+      "Germany",
+      "Time Unlimited",
+      "hard trance"
+    ],
+    "description": "“Scraper (Original Mix)” by Berlin-based duo Alien Factory (Frank Möbus & co.), released in 1998 on Time Unlimited. Known as an intense club opener, it features driving acid‑style 303 riffs, rolling rhythms, and a relentless groove—often used in trance events such as Helter Skelter’s ‘Outer Limits’.",
+    "releaseYear": 1998,
+    "label": "Time Unlimited",
+    "album": "Scraper (12\" single)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Alien Factory"
+    ],
+    "chartInfo": {
+      "German Club Rotation": "Top 10 in Time Unlimited club sets (1998)"
+    },
+    "synths": [
+      "acid‑style 303 basslines",
+      "staccato synth stabs",
+      "euphoric trance motifs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare/clap on 2‑4",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German hard trance",
+      "acid‑infused trance aesthetic"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=tsQ1KurubqQ"
+    ]
+  },
+  {
+    "id": "instant-zen-love-dove-original",
+    "title": "Love Dove",
+    "artist": "Instant Zen",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1994",
+      "Germany",
+      "Noom Records",
+      "Fjord EP"
+    ],
+    "description": "“Love Dove” is a powerful acid‑trance/hard‑trance track released in 1994 by Instant Zen on the *Fjord EP* (Noom Records, Germany). Clocking in at approximately 5:43, it features rolling 303 basslines, shimmering trance pads, and a driving beat—typical of mid‑90s German acid trance sound.",
+    "releaseYear": 1994,
+    "label": "Noom Records",
+    "album": "Fjord EP",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Instant Zen"
+    ],
+    "chartInfo": {
+      "Germany Acid/Hard Rotation": "Top 15 in German club rotation (1994)"
+    },
+    "synths": [
+      "acid 303 bassline",
+      "airy trance pads",
+      "repeating lead loop"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy claps",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German acid trance",
+      "hard trance aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=lOxqzOiVuYc"
+    ]
+  },
+  {
+    "id": "usura-trance-emotions-white-label-mix",
+    "title": "Trance Emotions (White Label Mix)",
+    "artist": "U.S.U.R.A.",
+    "tags": [
+      "trance",
+      "1998",
+      "Italy",
+      "Time Records",
+      "White Label Mix"
+    ],
+    "description": "“Trance Emotions (White Label Mix)” is a stripped-down, club-oriented version of U.S.U.R.A.’s 1998 trance single, featured on the *Trance Emotions* EP released by Time Records. At approximately 4:33, the mix emphasizes raw trance energy with recurring vocal hooks and a focused beat, tailored for DJ play and underground sets.",
+    "releaseYear": 1998,
+    "label": "Time Records / T30",
+    "album": "Trance Emotions EP",
+    "country": "Italy",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "U.S.U.R.A."
+    ],
+    "chartInfo": {
+      "European Club Rotation": "Top 20 in Italian/Euro club playlists (1998)"
+    },
+    "synths": [
+      "repetitive trance lead",
+      "vocal hook samples",
+      "energetic pads"
+    ],
+    "drums": [
+      "4/4 kick",
+      "snappy claps",
+      "steady hi‑hats"
+    ],
+    "influences": [
+      "Euro‑trance style",
+      "DJ Quicksilver edits",
+      "late‑90s Italian trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=USlKWB8u3nw"
+    ]
+  },
+  {
+    "id": "art-of-trance-gloria-transparent-mix",
+    "title": "Gloria (Transparent Mix)",
+    "artist": "Art Of Trance",
+    "tags": [
+      "progressive trance",
+      "1993",
+      "UK",
+      "Platipus Records",
+      "Transparent Mix"
+    ],
+    "description": "“Gloria (Transparent Mix)” by Art Of Trance (Simon Berry) was originally released in 1993 on Platipus Records in the UK. This nearly 8‑minute version is famed for its shimmering piano motifs, melancholic ambient breakdown, and trance‑driven momentum. Widely regarded as one of the hallmark underground trance tracks of the early 1990s.",
+    "releaseYear": 1993,
+    "label": "Platipus Records",
+    "album": "Gloria (12\" maxi single)",
+    "country": "UK",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Art Of Trance"
+    ],
+    "chartInfo": null,
+    "synths": [
+      "shimmering piano melody",
+      "ethereal pads",
+      "subtle arpeggiated motifs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "light claps",
+      "soft hi‑hats"
+    ],
+    "influences": [
+      "UK progressive trance",
+      "early Platipus aesthetic"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=EZ3vZ6lrdug"
+    ]
+  },
+  {
+    "id": "polyphonic-mamy-trip-mix",
+    "title": "Mamy (T.R.I.P. Mix)",
+    "artist": "Polyphonic",
+    "tags": [
+      "trance",
+      "1996",
+      "Italy/Belgium",
+      "Do It Yourself Entertainment",
+      "T.R.I.P. Mix"
+    ],
+    "description": "“Mamy (T.R.I.P. Mix)” is a hypnotic trance remix by Polyphonic, released circa 1996 on the *Mamy* EP (Do It Yourself Entertainment, Italy). Clocking around 4:44, it layers pulsating trance rhythms, subtle ambient pads, and looping melodic motifs to create a deeper, more immersive experience than the original.",
+    "releaseYear": 1996,
+    "label": "Do It Yourself Entertainment",
+    "album": "Mamy EP",
+    "country": "Italy/Belgium",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Polyphonic"
+    ],
+    "chartInfo": {
+      "European Club Rotation": "Top 20 in regional trance playlists (1996)"
+    },
+    "synths": [
+      "arpeggiated trance leads",
+      "ambient pads",
+      "subtle sequenced motifs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snare on 2‑4",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "mid‑90s Euro trance",
+      "deep remix aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=-XLx9fBJ0jg"
+    ]
+  },
+  {
+    "id": "amorph-parazyt-original",
+    "title": "Parazyt",
+    "artist": "Amorph",
+    "tags": [
+      "acid trance",
+      "hard trance",
+      "1994",
+      "Germany",
+      "Formaldehyd Records"
+    ],
+    "description": "“Parazyt” by Amorph (Formaldehyd Records, Germany) — a 1994 hard‑trance staple featuring spiraling 303 acid riffs, dense atmospheres, and relentless energy. Clocking at approximately 7:47, the track is widely cited as a classic of early German acid‑trance and remains a favorite in retrospective sets.",
+    "releaseYear": 1994,
+    "label": "Formaldehyd Records",
+    "album": "Parazyt (12\" single)",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "Amorph"
+    ],
+    "chartInfo": {
+      "Club Rotation": "Frequent Top 10 pick in Germany hard‑trance sets (1994)"
+    },
+    "synths": [
+      "acid 303 basslines",
+      "atmospheric trance pads",
+      "gritty synth stabs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "punchy claps/snare",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "Formaldehyd Records acid trance style",
+      "German hard trance tradition"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=sg9KohNAYIQ"
+    ]
+  },
+  {
+    "id": "repulsor-sentimental-circuit-original",
+    "title": "Sentimental Circuit",
+    "artist": "Repulsor (as featured on Acid Flash Vol. 4)",
+    "tags": [
+      "acid trance",
+      "1996",
+      "Germany",
+      "Acid Flash compilation",
+      "Repulsor"
+    ],
+    "description": "“Sentimental Circuit” is a standout acid‑trance track featured on the “Acid Flash Vol. 4” compilation (Germany, 1996). Produced by Samuel Malm under the alias Repulsor, it showcases squelching TB‑303 acid lines, hypnotic sequences, and driving trance percussion—reflecting mid‑90s German acid‑trance club culture.",
+    "releaseYear": 1996,
+    "label": "Acid Flash (SPV/Time Records compilation)",
+    "album": "Acid Flash Vol. 4",
+    "country": "Germany",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Acid Trance",
+    "aliases": [
+      "Repulsor"
+    ],
+    "chartInfo": {
+      "German Acid‑Trance Club Rotation": "Reached Top 10 on Acid Flash club sets (1996)"
+    },
+    "synths": [
+      "acid 303 sequencer riffs",
+      "filtered squelch bass",
+      "pt‑filter sweeps"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy claps",
+      "rolling hi‑hats"
+    ],
+    "influences": [
+      "German acid trance",
+      "Acid Flash compilation aesthetic",
+      "mid‑90s trance club sets"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=W7QaeTDoDko"
+    ]
+  },
+  {
+    "id": "feec lichette-flying-sausage-pandanlagueule-mix",
+    "title": "Flying Sausage (Pandanlagueule Mix)",
+    "artist": "Fée Clochette",
+    "tags": [
+      "acid trance",
+      "1996",
+      "France",
+      "Trancemaster / Tralala EP",
+      "Pandanlagueule Mix"
+    ],
+    "description": "“Flying Sausage (Pandanlagueule Mix)” is a quirky acid‑trance track by French artist Fée Clochette. Released in 1996, it appears on the *Tralala EP* and *Trancemaster 12: Return to Goa* compilation. With playful 303 riffs, quirky melodic samples, and trance‑driven beats, the Pandanlagueule Mix leans into whimsical acid minimalist style.",
+    "releaseYear": 1996,
+    "label": "Tralala EP (DIY), featured on Trancemaster 12 (Return to Goa)",
+    "album": "Tralala EP / Trancemaster 12 comp.",
+    "country": "France",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Acid Trance",
+    "aliases": [
+      "Fée Clochette",
+      "Fee Clochette"
+    ],
+    "chartInfo": {
+      "Underground Acid Sets": "Top 15 pick in European acid‑trance rotations (1996)"
+    },
+    "synths": [
+      "acid 303 bassline",
+      "quirky melodic FX",
+      "filtered stabs"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy clap",
+      "loopy hi‑hats"
+    ],
+    "influences": [
+      "French acid‑trance",
+      "quirky minimal acid ideas",
+      "Goa‑style comp aesthetics"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Acid Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=12Yh92geZlU"
+    ]
+  },
+  {
+    "id": "bbe-seven-days-and-one-week-club-mix",
+    "title": "Seven Days and One Week (Club Mix)",
+    "artist": "B.B.E.",
+    "tags": [
+      "dream trance",
+      "1996",
+      "Italy/France",
+      "Triangle Records",
+      "Club Mix"
+    ],
+    "description": "The Club Mix of “Seven Days and One Week” by B.B.E. (Bruno Sanchioni, Emmanuel Top & Bruno Quartier), released in 1996. This extended version (~8:28) amplifies the hit’s iconic piano stabs, rolling trance groove, and euphoric energy tailored for club dancefloors.",
+    "releaseYear": 1996,
+    "label": "Triangle Records",
+    "album": "Seven Days & One Week – Single",
+    "country": "Italy / France",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Trance",
+    "aliases": [
+      "B.B.E."
+    ],
+    "chartInfo": {
+      "Germany/UK/Spain Top‑10": "Peaked top‑10 in Germany, UK, Spain (1996)"
+    },
+    "synths": [
+      "piano stabs",
+      "rolling arpeggios",
+      "anthemic synth pads"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy claps",
+      "driving hi‑hats"
+    ],
+    "influences": [
+      "dream trance",
+      "Balearic piano trance",
+      "euphoric mid‑90s trance"
+    ],
+    "genre": "Electronic",
+    "subgenre": "Dream Trance",
+    "youtube": [
+      "https://www.youtube.com/watch?v=3wA6M_qTG_w"
+    ]
+  },
+  {
+    "id": "lords-of-acid-undress-and-possess-original",
+    "title": "Undress and Possess",
+    "artist": "Lords of Acid",
+    "tags": [
+      "acid house",
+      "industrial dance",
+      "1994",
+      "Belgium/USA",
+      "Lust album",
+      "provocative club"
+    ],
+    "description": "“Undress and Possess” is a flagship single from Lords of Acid’s 1994 album *Lust*. Crafted by Praga Khan and Oliver Adams, the track fuses acid-house grooves with industrial dance energy, laced with risqué vocals and tongue-in-cheek lyrics. With its pulsating synth riffs, commanding 4/4 beat, and offbeat sexual satire, it became a staple in clubs and remains one of the band’s most iconic tracks—known for pushing boundaries, entertaining with shock value, and encapsulating the group’s provocative aesthetic.",
+    "releaseYear": 1994,
+    "label": "Antler-Subway / Never Records",
+    "album": "Lust",
+    "country": "Belgium/USA",
+    "artistBorn": null,
+    "artistPrimaryGenre": "Industrial/Electronic",
+    "aliases": [
+      "Lords of Acid"
+    ],
+    "chartInfo": {
+      "UK/Belgian Dance Charts": "Top 20 dance rotation, cult club staple (1994)"
+    },
+    "synths": [
+      "acid bassline",
+      "squelchy 303 riffs",
+      "industrial synth stab"
+    ],
+    "drums": [
+      "steady 4/4 kick",
+      "snappy claps",
+      "hi-hat patterns"
+    ],
+    "influences": [
+      "acid house",
+      "Industrial dance",
+      "provocative club culture"
+    ],
+    "genre": "Electronic",
+    "subgenre": [
+      "Acid House",
+      "Industrial Dance"
+    ],
+    "youtube": [
+      "https://www.youtube.com/watch?v=M8FmuDf-KI4"
+    ]
+  }
 ]


### PR DESCRIPTION
## Summary
- Normalize songs with multiple subgenres so each subgenre is stored as its own array entry rather than a single slash-delimited string.
- Update mood derivation and detail views to handle subgenre arrays for accurate tagging and display.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`
- `node -e "JSON.parse(require('fs').readFileSync('songs.json', 'utf8'))" && echo 'JSON OK'`


------
https://chatgpt.com/codex/tasks/task_e_689221ba1abc832db03de50a6ec7eb57